### PR TITLE
feat: add check for source traces missing pcb traces

### DIFF
--- a/docs/PCB_COMPONENT_OVERVIEW.md
+++ b/docs/PCB_COMPONENT_OVERVIEW.md
@@ -1,0 +1,397 @@
+# Circuit JSON Specification: PCB Component Overview
+
+Any type below can be imported from `circuit-json`. Every type has a corresponding
+snake_case version which is a zod type that can be used to parse unknown json,
+for example `PcbComponent` has a `pcb_component.parse` function that you
+can also import.
+
+```ts
+export interface PcbFabricationNotePath {
+  type: "pcb_fabrication_note_path"
+  pcb_fabrication_note_path_id: string
+  pcb_component_id: string
+  layer: LayerRef
+  route: Point[]
+  stroke_width: Length
+  color?: string
+}
+
+export interface PcbComponent {
+  type: "pcb_component"
+  pcb_component_id: string
+  source_component_id: string
+  center: Point
+  layer: LayerRef
+  rotation: Rotation
+  width: Length
+  height: Length
+}
+
+export interface PcbPortNotMatchedError {
+  type: "pcb_port_not_matched_error"
+  pcb_error_id: string
+  error_type: "pcb_port_not_matched_error"
+  message: string
+  pcb_component_ids: string[]
+}
+
+export interface PcbSolderPasteCircle {
+  type: "pcb_solder_paste"
+  shape: "circle"
+  pcb_solder_paste_id: string
+  x: Distance
+  y: Distance
+  radius: number
+  layer: LayerRef
+  pcb_component_id?: string
+  pcb_smtpad_id?: string
+}
+
+export interface PcbSolderPasteRect {
+  type: "pcb_solder_paste"
+  shape: "rect"
+  pcb_solder_paste_id: string
+  x: Distance
+  y: Distance
+  width: number
+  height: number
+  layer: LayerRef
+  pcb_component_id?: string
+  pcb_smtpad_id?: string
+}
+
+export type PcbSolderPaste = PcbSolderPasteCircle | PcbSolderPasteRect
+
+export interface PcbSilkscreenText {
+  type: "pcb_silkscreen_text"
+  pcb_silkscreen_text_id: string
+  font: "tscircuit2024"
+  font_size: Length
+  pcb_component_id: string
+  text: string
+  layer: LayerRef
+  is_mirrored?: boolean
+  anchor_position: Point
+  anchor_alignment:
+    | "center"
+    | "top_left"
+    | "top_right"
+    | "bottom_left"
+    | "bottom_right"
+}
+
+export interface PcbTraceError {
+  type: "pcb_trace_error"
+  pcb_trace_error_id: string
+  error_type: "pcb_trace_error"
+  message: string
+  center?: Point
+  pcb_trace_id: string
+  source_trace_id: string
+  pcb_component_ids: string[]
+  pcb_port_ids: string[]
+}
+
+export interface PcbTraceMissingError {
+  type: "pcb_trace_missing_error"
+  pcb_trace_missing_error_id: string
+  error_type: "pcb_trace_missing_error"
+  message: string
+  center?: Point
+  source_trace_id: string
+  pcb_component_ids: string[]
+  pcb_port_ids: string[]
+}
+
+export interface PcbSilkscreenPill {
+  type: "pcb_silkscreen_pill"
+  pcb_silkscreen_pill_id: string
+  pcb_component_id: string
+  center: Point
+  width: Length
+  height: Length
+  layer: LayerRef
+}
+
+export interface PcbPlatedHoleCircle {
+  type: "pcb_plated_hole"
+  shape: "circle"
+  outer_diameter: number
+  hole_diameter: number
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+  pcb_plated_hole_id: string
+}
+
+export interface PcbPlatedHoleOval {
+  type: "pcb_plated_hole"
+  shape: "oval" | "pill"
+  outer_width: number
+  outer_height: number
+  hole_width: number
+  hole_height: number
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+  pcb_plated_hole_id: string
+}
+
+export interface PcbHoleCircularWithRectPad {
+  type: "pcb_plated_hole"
+  shape: "circular_hole_with_rect_pad"
+  hole_shape: "circle"
+  pad_shape: "rect"
+  hole_diameter: number
+  rect_pad_width: number
+  rect_pad_height: number 
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+  pcb_plated_hole_id: string
+}
+
+export type PcbPlatedHole = PcbPlatedHoleCircle | PcbPlatedHoleOval | PcbHoleCircularWithRectPad
+
+export interface PcbFabricationNoteText {
+  type: "pcb_fabrication_note_text"
+  pcb_fabrication_note_text_id: string
+  font: "tscircuit2024"
+  font_size: Length
+  pcb_component_id: string
+  text: string
+  layer: VisibleLayer
+  anchor_position: Point
+  anchor_alignment:
+    | "center"
+    | "top_left"
+    | "top_right"
+    | "bottom_left"
+    | "bottom_right"
+  color?: string
+}
+
+export interface PcbSilkscreenCircle {
+  type: "pcb_silkscreen_circle"
+  pcb_silkscreen_circle_id: string
+  pcb_component_id: string
+  center: Point
+  radius: Length
+  layer: VisibleLayer
+}
+
+export interface PcbSilkscreenPath {
+  type: "pcb_silkscreen_path"
+  pcb_silkscreen_path_id: string
+  pcb_component_id: string
+  layer: VisibleLayerRef
+  route: Point[]
+  stroke_width: Length
+}
+
+export interface PcbText {
+  type: "pcb_text"
+  pcb_text_id: string
+  text: string
+  center: Point
+  layer: LayerRef
+  width: Length
+  height: Length
+  lines: number
+  align: "bottom-left"
+}
+
+export interface PCBKeepout {
+  type: "pcb_keepout"
+  shape: "rect" | "circle"
+  center: Point
+  width?: Distance
+  height?: Distance
+  radius?: Distance
+  pcb_keepout_id: string
+  layers: string[]
+  description?: string
+}
+
+export interface PcbVia {
+  type: "pcb_via"
+  pcb_via_id: string
+  x: Distance
+  y: Distance
+  outer_diameter: Distance
+  hole_diameter: Distance
+  layers: LayerRef[]
+  pcb_trace_id?: string
+}
+
+export interface PcbSilkscreenOval {
+  type: "pcb_silkscreen_oval"
+  pcb_silkscreen_oval_id: string
+  pcb_component_id: string
+  center: Point
+  radius_x: Distance
+  radius_y: Distance
+  layer: VisibleLayer
+}
+
+export interface PcbPlacementError {
+  type: "pcb_placement_error"
+  pcb_placement_error_id: string
+  error_type: "pcb_placement_error"
+  message: string
+}
+
+export interface PcbPort {
+  type: "pcb_port"
+  pcb_port_id: string
+  source_port_id: string
+  pcb_component_id: string
+  x: Distance
+  y: Distance
+  layers: LayerRef[]
+}
+
+export interface PcbSmtPadCircle {
+  type: "pcb_smtpad"
+  shape: "circle"
+  pcb_smtpad_id: string
+  x: Distance
+  y: Distance
+  radius: number
+  layer: LayerRef
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+}
+
+export interface PcbSmtPadRect {
+  type: "pcb_smtpad"
+  shape: "rect"
+  pcb_smtpad_id: string
+  x: Distance
+  y: Distance
+  width: number
+  height: number
+  layer: LayerRef
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+}
+
+
+export interface PcbSmtPadPolygon {
+  type: "pcb_smtpad"
+  shape: "polygon"
+  pcb_smtpad_id: string
+  pcb_group_id?: string
+  subcircuit_id?: string
+  points: Point[]
+  layer: LayerRef
+  port_hints?: string[]
+  pcb_component_id?: string
+  pcb_port_id?: string
+}
+
+
+export type PcbSmtPad =
+  | PcbSmtPadCircle
+  | PcbSmtPadRect
+  | PcbSmtPadPolygon
+
+export interface PcbSilkscreenLine {
+  type: "pcb_silkscreen_line"
+  pcb_silkscreen_line_id: string
+  pcb_component_id: string
+  stroke_width: Distance
+  x1: Distance
+  y1: Distance
+  x2: Distance
+  y2: Distance
+  layer: VisibleLayer
+}
+
+export interface PcbHoleCircleOrSquare {
+  type: "pcb_hole"
+  pcb_hole_id: string
+  hole_shape: "circle" | "square"
+  hole_diameter: number
+  x: Distance
+  y: Distance
+}
+
+export interface PcbHoleOval {
+  type: "pcb_hole"
+  pcb_hole_id: string
+  hole_shape: "oval"
+  hole_width: number
+  hole_height: number
+  x: Distance
+  y: Distance
+}
+
+export type PcbHole = PcbHoleCircleOrSquare | PcbHoleOval
+
+export interface PcbTraceRoutePointWire {
+  route_type: "wire"
+  x: Distance
+  y: Distance
+  width: Distance
+  start_pcb_port_id?: string
+  end_pcb_port_id?: string
+  layer: LayerRef
+}
+
+export interface PcbTraceRoutePointVia {
+  route_type: "via"
+  x: Distance
+  y: Distance
+  from_layer: string
+  to_layer: string
+}
+
+export type PcbTraceRoutePoint = PcbTraceRoutePointWire | PcbTraceRoutePointVia
+
+export interface PcbTrace {
+  type: "pcb_trace"
+  source_trace_id?: string
+  pcb_component_id?: string
+  pcb_trace_id: string
+  route_order_index?: number
+  route_thickness_mode?: "constant" | "interpolated"
+  should_round_corners?: boolean
+  route: Array<PcbTraceRoutePoint>
+}
+
+export interface PcbBreakoutPoint {
+  type: "pcb_breakout_point"
+  pcb_breakout_point_id: string
+  pcb_group_id: string
+  subcircuit_id?: string
+  source_trace_id?: string
+  source_port_id?: string
+  source_net_id?: string
+  x: Distance
+  y: Distance
+}
+
+export interface PcbBoard {
+  type: "pcb_board"
+  pcb_board_id: string
+  width: Length
+  height: Length
+  thickness: Length
+  num_layers: number
+  center: Point
+  outline?: Point[]
+}
+
+```

--- a/index.ts
+++ b/index.ts
@@ -3,4 +3,5 @@ export { checkEachPcbTraceNonOverlapping } from "./lib/check-each-pcb-trace-non-
 export { NetManager } from "./lib/net-manager"
 export { checkViasOffBoard } from "./lib/check-pcb-components-out-of-board/checkViasOffBoard"
 export { checkSameNetViaSpacing } from "./lib/check-same-net-via-spacing"
+export { checkSourceTracesHavePcbTraces } from "./lib/check-source-traces-have-pcb-traces"
 export { runAllChecks } from "./lib/run-all-checks"

--- a/lib/check-source-traces-have-pcb-traces.ts
+++ b/lib/check-source-traces-have-pcb-traces.ts
@@ -1,0 +1,44 @@
+import type {
+  AnyCircuitElement,
+  PcbTraceError,
+  SourceTrace,
+  PcbTrace,
+} from "circuit-json"
+
+/**
+ * Check that each source_trace which connects source ports has at least one
+ * pcb_trace associated with it. If a source_trace has no corresponding
+ * pcb_trace, return an error for that source_trace.
+ */
+function checkSourceTracesHavePcbTraces(
+  soup: AnyCircuitElement[],
+): PcbTraceError[] {
+  const errors: PcbTraceError[] = []
+  const sourceTraces = soup.filter(
+    (el) => el.type === "source_trace",
+  ) as SourceTrace[]
+  const pcbTraces = soup.filter((el) => el.type === "pcb_trace") as PcbTrace[]
+
+  for (const sourceTrace of sourceTraces) {
+    if (!sourceTrace.connected_source_port_ids?.length) continue
+    const hasPcbTrace = pcbTraces.some(
+      (pcbTrace) => pcbTrace.source_trace_id === sourceTrace.source_trace_id,
+    )
+    if (!hasPcbTrace) {
+      errors.push({
+        type: "pcb_trace_error",
+        error_type: "pcb_trace_error",
+        message: `Trace [${sourceTrace.display_name ?? sourceTrace.source_trace_id}] has no PCB traces`,
+        source_trace_id: sourceTrace.source_trace_id,
+        pcb_trace_id: "",
+        pcb_trace_error_id: "",
+        pcb_component_ids: [],
+        pcb_port_ids: [],
+      })
+    }
+  }
+
+  return errors
+}
+
+export { checkSourceTracesHavePcbTraces }

--- a/lib/run-all-checks.ts
+++ b/lib/run-all-checks.ts
@@ -4,6 +4,7 @@ import { checkSameNetViaSpacing } from "./check-same-net-via-spacing"
 import { checkViasOffBoard } from "./check-pcb-components-out-of-board/checkViasOffBoard"
 import { checkPcbComponentsOutOfBoard } from "./check-pcb-components-out-of-board/checkPcbComponentsOutOfBoard"
 import { checkTracesAreContiguous } from "./check-traces-are-contiguous/check-traces-are-contiguous"
+import { checkSourceTracesHavePcbTraces } from "./check-source-traces-have-pcb-traces"
 import type { AnyCircuitElement } from "circuit-json"
 
 export async function runAllChecks(circuitJson: AnyCircuitElement[]) {
@@ -14,5 +15,6 @@ export async function runAllChecks(circuitJson: AnyCircuitElement[]) {
     ...checkViasOffBoard(circuitJson),
     ...checkPcbComponentsOutOfBoard(circuitJson),
     ...checkTracesAreContiguous(circuitJson),
+    ...checkSourceTracesHavePcbTraces(circuitJson),
   ]
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/debug": "^4.1.12",
     "bun-match-svg": "^0.0.11",
     "circuit-to-svg": "^0.0.166",
+    "circuit-json": "^0.0.228",
     "debug": "^4.3.5",
     "tscircuit": "^0.0.525",
     "zod": "^3.23.8",

--- a/tests/lib/check-source-traces-have-pcb-traces.test.ts
+++ b/tests/lib/check-source-traces-have-pcb-traces.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { checkSourceTracesHavePcbTraces } from "lib/check-source-traces-have-pcb-traces"
+
+describe("checkSourceTracesHavePcbTraces", () => {
+  test("returns error when source trace has no pcb traces", () => {
+    const soup = [
+      {
+        type: "source_trace",
+        source_trace_id: "trace1",
+        connected_source_port_ids: ["p1", "p2"],
+        connected_source_net_ids: [],
+        display_name: "trace1",
+      },
+    ]
+
+    const errors = checkSourceTracesHavePcbTraces(soup as any)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("trace1")
+  })
+
+  test("does not return error when pcb trace exists", () => {
+    const soup = [
+      {
+        type: "source_trace",
+        source_trace_id: "trace1",
+        connected_source_port_ids: ["p1", "p2"],
+        connected_source_net_ids: [],
+        display_name: "trace1",
+      },
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "pcb1",
+        source_trace_id: "trace1",
+        route: [],
+      },
+    ]
+
+    const errors = checkSourceTracesHavePcbTraces(soup as any)
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/tests/lib/check-source-traces-have-pcb-traces.test.ts
+++ b/tests/lib/check-source-traces-have-pcb-traces.test.ts
@@ -3,7 +3,7 @@ import { checkSourceTracesHavePcbTraces } from "lib/check-source-traces-have-pcb
 
 describe("checkSourceTracesHavePcbTraces", () => {
   test("returns error when source trace has no pcb traces", () => {
-    const soup = [
+    const circuitJson = [
       {
         type: "source_trace",
         source_trace_id: "trace1",
@@ -13,13 +13,53 @@ describe("checkSourceTracesHavePcbTraces", () => {
       },
     ]
 
-    const errors = checkSourceTracesHavePcbTraces(soup as any)
+    const errors = checkSourceTracesHavePcbTraces(circuitJson as any)
     expect(errors).toHaveLength(1)
     expect(errors[0].message).toContain("trace1")
   })
 
+  test("returns error with correct PCB component and port IDs", () => {
+    const circuitJson = [
+      {
+        type: "source_trace",
+        source_trace_id: "trace1",
+        connected_source_port_ids: ["source_port_1", "source_port_2"],
+        connected_source_net_ids: [],
+        display_name: "trace1",
+      },
+      {
+        type: "pcb_port",
+        pcb_port_id: "pcb_port_1",
+        source_port_id: "source_port_1",
+        pcb_component_id: "pcb_component_1",
+        x: 0,
+        y: 0,
+        layers: ["top"],
+      },
+      {
+        type: "pcb_port",
+        pcb_port_id: "pcb_port_2",
+        source_port_id: "source_port_2",
+        pcb_component_id: "pcb_component_2",
+        x: 1,
+        y: 1,
+        layers: ["top"],
+      },
+    ]
+
+    const errors = checkSourceTracesHavePcbTraces(circuitJson as any)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("trace1")
+    expect(errors[0].pcb_component_ids).toEqual([
+      "pcb_component_1",
+      "pcb_component_2",
+    ])
+    expect(errors[0].pcb_port_ids).toEqual(["pcb_port_1", "pcb_port_2"])
+    expect(errors[0].source_trace_id).toBe("trace1")
+  })
+
   test("does not return error when pcb trace exists", () => {
-    const soup = [
+    const circuitJson = [
       {
         type: "source_trace",
         source_trace_id: "trace1",
@@ -35,7 +75,7 @@ describe("checkSourceTracesHavePcbTraces", () => {
       },
     ]
 
-    const errors = checkSourceTracesHavePcbTraces(soup as any)
+    const errors = checkSourceTracesHavePcbTraces(circuitJson as any)
     expect(errors).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- add check to verify each source trace has a corresponding pcb trace
- wire new check into runAllChecks and exports
- test source trace check

## Testing
- `bun run format:check`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68999f38e4bc83278ae6e9f25d3fa1ac