### PR TITLE
Disconnected traces now throws error

### DIFF
--- a/tests/assets/repro-trace-disconnection.json
+++ b/tests/assets/repro-trace-disconnection.json
@@ -8,16 +8,10 @@
     "rect_pad_width": 1.5,
     "rect_pad_height": 1.5,
     "shape": "circular_hole_with_rect_pad",
-    "port_hints": [
-      "unnamed_platedhole1",
-      "1"
-    ],
+    "port_hints": ["unnamed_platedhole1", "1"],
     "x": -2.08,
     "y": 7,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "rect_border_radius": 0
@@ -30,16 +24,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole2",
-      "2"
-    ],
+    "port_hints": ["unnamed_platedhole2", "2"],
     "x": 0.45999999999999996,
     "y": 7,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2"
   },
@@ -51,16 +39,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole3",
-      "3"
-    ],
+    "port_hints": ["unnamed_platedhole3", "3"],
     "x": 3,
     "y": 7,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2"
   },
@@ -72,16 +54,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole4",
-      "4"
-    ],
+    "port_hints": ["unnamed_platedhole4", "4"],
     "x": 5.54,
     "y": 7,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2"
   },
@@ -93,16 +69,10 @@
     "outer_diameter": 1.5,
     "hole_diameter": 1,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole5",
-      "5"
-    ],
+    "port_hints": ["unnamed_platedhole5", "5"],
     "x": 8.08,
     "y": 7,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2"
   },
@@ -114,16 +84,10 @@
     "outer_diameter": 1.9999959999999999,
     "hole_diameter": 1.3000228,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole6",
-      "4"
-    ],
+    "port_hints": ["unnamed_platedhole6", "4"],
     "x": 5.249929999999836,
     "y": -12.249932000000058,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0"
   },
@@ -135,16 +99,10 @@
     "outer_diameter": 1.9999959999999999,
     "hole_diameter": 1.3000228,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole7",
-      "2"
-    ],
+    "port_hints": ["unnamed_platedhole7", "2"],
     "x": 5.249929999999836,
     "y": -7.750067999999942,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0"
   },
@@ -156,16 +114,10 @@
     "outer_diameter": 1.9999959999999999,
     "hole_diameter": 1.3000228,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole8",
-      "1"
-    ],
+    "port_hints": ["unnamed_platedhole8", "1"],
     "x": -1.2499299999999494,
     "y": -7.750067999999942,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0"
   },
@@ -177,16 +129,10 @@
     "outer_diameter": 1.9999959999999999,
     "hole_diameter": 1.3000228,
     "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole9",
-      "3"
-    ],
+    "port_hints": ["unnamed_platedhole9", "3"],
     "x": -1.2499299999999494,
     "y": -12.249932000000058,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0"
   },
@@ -199,9 +145,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin1"
-    ],
+    "port_hints": ["pin1"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": -2.925064000000134,
@@ -217,9 +161,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin2"
-    ],
+    "port_hints": ["pin2"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": -2.2750780000000077,
@@ -235,9 +177,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin3"
-    ],
+    "port_hints": ["pin3"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": -1.625092000000109,
@@ -253,9 +193,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin4"
-    ],
+    "port_hints": ["pin4"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": -0.9751059999999827,
@@ -271,9 +209,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin5"
-    ],
+    "port_hints": ["pin5"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": -0.3248660000000429,
@@ -289,9 +225,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin6"
-    ],
+    "port_hints": ["pin6"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": 0.3251200000000834,
@@ -307,9 +241,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin7"
-    ],
+    "port_hints": ["pin7"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": 0.9751059999999823,
@@ -325,9 +257,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin8"
-    ],
+    "port_hints": ["pin8"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": 1.6250919999999949,
@@ -343,9 +273,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin9"
-    ],
+    "port_hints": ["pin9"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": 2.2750780000000077,
@@ -361,9 +289,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin10"
-    ],
+    "port_hints": ["pin10"],
     "is_covered_with_solder_mask": false,
     "x": 2.870961999999963,
     "y": 2.9250640000000203,
@@ -379,9 +305,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin20"
-    ],
+    "port_hints": ["pin20"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": -2.925064000000134,
@@ -397,9 +321,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin19"
-    ],
+    "port_hints": ["pin19"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": -2.2750780000000077,
@@ -415,9 +337,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin18"
-    ],
+    "port_hints": ["pin18"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": -1.6250920000001086,
@@ -433,9 +353,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin17"
-    ],
+    "port_hints": ["pin17"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": -0.9751059999999823,
@@ -451,9 +369,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin16"
-    ],
+    "port_hints": ["pin16"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": -0.32486600000004257,
@@ -469,9 +385,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin15"
-    ],
+    "port_hints": ["pin15"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": 0.32512000000008373,
@@ -487,9 +401,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin14"
-    ],
+    "port_hints": ["pin14"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": 0.9751059999999827,
@@ -505,9 +417,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin13"
-    ],
+    "port_hints": ["pin13"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": 1.6250919999999953,
@@ -523,9 +433,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin12"
-    ],
+    "port_hints": ["pin12"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": 2.2750780000000077,
@@ -541,9 +449,7 @@
     "shape": "rect",
     "width": 1.7420082,
     "height": 0.3640074,
-    "port_hints": [
-      "pin11"
-    ],
+    "port_hints": ["pin11"],
     "is_covered_with_solder_mask": false,
     "x": -2.870961999999963,
     "y": 2.9250640000000203,
@@ -559,10 +465,7 @@
     "shape": "rect",
     "width": 0.95,
     "height": 0.8,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 10,
     "y": 2.825,
@@ -578,10 +481,7 @@
     "shape": "rect",
     "width": 0.95,
     "height": 0.8,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 10,
     "y": 1.175,
@@ -597,10 +497,7 @@
     "shape": "rect",
     "width": 0.95,
     "height": 0.8,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 7,
     "y": 2.825,
@@ -616,10 +513,7 @@
     "shape": "rect",
     "width": 0.95,
     "height": 0.8,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 7,
     "y": 1.175,
@@ -635,10 +529,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 2.825,
     "y": -5,
@@ -654,10 +545,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 1.175,
     "y": -5,
@@ -673,10 +561,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 8.175,
     "y": -3,
@@ -692,10 +577,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 9.825,
     "y": -3,
@@ -711,10 +593,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "1",
-      "left"
-    ],
+    "port_hints": ["1", "left"],
     "is_covered_with_solder_mask": false,
     "x": 9.825,
     "y": -6,
@@ -730,10 +609,7 @@
     "shape": "rect",
     "width": 0.8,
     "height": 0.95,
-    "port_hints": [
-      "2",
-      "right"
-    ],
+    "port_hints": ["2", "right"],
     "is_covered_with_solder_mask": false,
     "x": 8.175,
     "y": -6,
@@ -904,10 +780,7 @@
     "source_port_id": "source_port_0",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -916,10 +789,7 @@
     "source_port_id": "source_port_1",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
@@ -929,10 +799,7 @@
     "source_port_id": "source_port_2",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
@@ -942,10 +809,7 @@
     "source_port_id": "source_port_3",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
@@ -955,10 +819,7 @@
     "source_port_id": "source_port_4",
     "name": "pin5",
     "pin_number": 5,
-    "port_hints": [
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["pin5", "5"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -967,10 +828,7 @@
     "source_port_id": "source_port_5",
     "name": "pin6",
     "pin_number": 6,
-    "port_hints": [
-      "pin6",
-      "6"
-    ],
+    "port_hints": ["pin6", "6"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -979,11 +837,7 @@
     "source_port_id": "source_port_6",
     "name": "VSS",
     "pin_number": 7,
-    "port_hints": [
-      "VSS",
-      "pin7",
-      "7"
-    ],
+    "port_hints": ["VSS", "pin7", "7"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -993,10 +847,7 @@
     "source_port_id": "source_port_7",
     "name": "pin8",
     "pin_number": 8,
-    "port_hints": [
-      "pin8",
-      "8"
-    ],
+    "port_hints": ["pin8", "8"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1005,11 +856,7 @@
     "source_port_id": "source_port_8",
     "name": "VDD",
     "pin_number": 9,
-    "port_hints": [
-      "VDD",
-      "pin9",
-      "9"
-    ],
+    "port_hints": ["VDD", "pin9", "9"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
@@ -1019,10 +866,7 @@
     "source_port_id": "source_port_9",
     "name": "pin10",
     "pin_number": 10,
-    "port_hints": [
-      "pin10",
-      "10"
-    ],
+    "port_hints": ["pin10", "10"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1031,10 +875,7 @@
     "source_port_id": "source_port_10",
     "name": "pin11",
     "pin_number": 11,
-    "port_hints": [
-      "pin11",
-      "11"
-    ],
+    "port_hints": ["pin11", "11"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1043,10 +884,7 @@
     "source_port_id": "source_port_11",
     "name": "pin12",
     "pin_number": 12,
-    "port_hints": [
-      "pin12",
-      "12"
-    ],
+    "port_hints": ["pin12", "12"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1055,10 +893,7 @@
     "source_port_id": "source_port_12",
     "name": "pin13",
     "pin_number": 13,
-    "port_hints": [
-      "pin13",
-      "13"
-    ],
+    "port_hints": ["pin13", "13"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1067,10 +902,7 @@
     "source_port_id": "source_port_13",
     "name": "pin14",
     "pin_number": 14,
-    "port_hints": [
-      "pin14",
-      "14"
-    ],
+    "port_hints": ["pin14", "14"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1079,10 +911,7 @@
     "source_port_id": "source_port_14",
     "name": "pin15",
     "pin_number": 15,
-    "port_hints": [
-      "pin15",
-      "15"
-    ],
+    "port_hints": ["pin15", "15"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1091,10 +920,7 @@
     "source_port_id": "source_port_15",
     "name": "pin16",
     "pin_number": 16,
-    "port_hints": [
-      "pin16",
-      "16"
-    ],
+    "port_hints": ["pin16", "16"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1103,10 +929,7 @@
     "source_port_id": "source_port_16",
     "name": "pin17",
     "pin_number": 17,
-    "port_hints": [
-      "pin17",
-      "17"
-    ],
+    "port_hints": ["pin17", "17"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1115,10 +938,7 @@
     "source_port_id": "source_port_17",
     "name": "pin18",
     "pin_number": 18,
-    "port_hints": [
-      "pin18",
-      "18"
-    ],
+    "port_hints": ["pin18", "18"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
@@ -1128,10 +948,7 @@
     "source_port_id": "source_port_18",
     "name": "pin19",
     "pin_number": 19,
-    "port_hints": [
-      "pin19",
-      "19"
-    ],
+    "port_hints": ["pin19", "19"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1140,10 +957,7 @@
     "source_port_id": "source_port_19",
     "name": "pin20",
     "pin_number": 20,
-    "port_hints": [
-      "pin20",
-      "20"
-    ],
+    "port_hints": ["pin20", "20"],
     "source_component_id": "source_component_0",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1154,9 +968,7 @@
     "name": "U1",
     "manufacturer_part_number": "CH32V003F4P6",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C5187096"
-      ]
+      "jlcpcb": ["C5187096"]
     },
     "source_group_id": "source_group_2"
   },
@@ -1165,10 +977,7 @@
     "source_port_id": "source_port_20",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1178,10 +987,7 @@
     "source_port_id": "source_port_21",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
@@ -1191,10 +997,7 @@
     "source_port_id": "source_port_22",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
@@ -1204,10 +1007,7 @@
     "source_port_id": "source_port_23",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
@@ -1217,10 +1017,7 @@
     "source_port_id": "source_port_24",
     "name": "pin5",
     "pin_number": 5,
-    "port_hints": [
-      "pin5",
-      "5"
-    ],
+    "port_hints": ["pin5", "5"],
     "source_component_id": "source_component_1",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
@@ -1241,13 +1038,7 @@
     "source_port_id": "source_port_25",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
@@ -1257,13 +1048,7 @@
     "source_port_id": "source_port_26",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_2",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
@@ -1274,11 +1059,7 @@
     "ftype": "simple_resistor",
     "name": "R1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C25803",
-        "C2907088",
-        "C2906980"
-      ]
+      "jlcpcb": ["C25803", "C2907088", "C2906980"]
     },
     "resistance": 100000,
     "display_resistance": "100kΩ",
@@ -1290,12 +1071,7 @@
     "source_port_id": "source_port_27",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
@@ -1305,12 +1081,7 @@
     "source_port_id": "source_port_28",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2"],
     "source_component_id": "source_component_3",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1321,11 +1092,7 @@
     "ftype": "simple_capacitor",
     "name": "C1",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C14663",
-        "C30926",
-        "C1591"
-      ]
+      "jlcpcb": ["C14663", "C30926", "C1591"]
     },
     "capacitance": 1e-7,
     "display_capacitance": "100n",
@@ -1337,10 +1104,7 @@
     "source_port_id": "source_port_29",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "1"
-    ],
+    "port_hints": ["pin1", "1"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1350,10 +1114,7 @@
     "source_port_id": "source_port_30",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "2"
-    ],
+    "port_hints": ["pin2", "2"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
@@ -1363,10 +1124,7 @@
     "source_port_id": "source_port_31",
     "name": "pin3",
     "pin_number": 3,
-    "port_hints": [
-      "pin3",
-      "3"
-    ],
+    "port_hints": ["pin3", "3"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1375,10 +1133,7 @@
     "source_port_id": "source_port_32",
     "name": "pin4",
     "pin_number": 4,
-    "port_hints": [
-      "pin4",
-      "4"
-    ],
+    "port_hints": ["pin4", "4"],
     "source_component_id": "source_component_4",
     "subcircuit_id": "subcircuit_source_group_2"
   },
@@ -1388,9 +1143,7 @@
     "name": "SW1",
     "ftype": "simple_push_button",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C110153"
-      ]
+      "jlcpcb": ["C110153"]
     },
     "are_pins_interchangeable": true,
     "source_group_id": "source_group_0"
@@ -1400,12 +1153,7 @@
     "source_port_id": "source_port_33",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "pos",
-      "anode",
-      "1"
-    ],
+    "port_hints": ["pin1", "pos", "anode", "1"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
@@ -1415,12 +1163,7 @@
     "source_port_id": "source_port_34",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "neg",
-      "cathode",
-      "2"
-    ],
+    "port_hints": ["pin2", "neg", "cathode", "2"],
     "source_component_id": "source_component_5",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1431,11 +1174,7 @@
     "ftype": "simple_capacitor",
     "name": "C2",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C14663",
-        "C30926",
-        "C1591"
-      ]
+      "jlcpcb": ["C14663", "C30926", "C1591"]
     },
     "capacitance": 1e-7,
     "display_capacitance": "100n",
@@ -1447,13 +1186,7 @@
     "source_port_id": "source_port_35",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
@@ -1463,13 +1196,7 @@
     "source_port_id": "source_port_36",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_6",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net6"
@@ -1480,11 +1207,7 @@
     "ftype": "simple_resistor",
     "name": "R2",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C21190",
-        "C25585",
-        "C115325"
-      ]
+      "jlcpcb": ["C21190", "C25585", "C115325"]
     },
     "resistance": 1000,
     "display_resistance": "1kΩ",
@@ -1496,13 +1219,7 @@
     "source_port_id": "source_port_37",
     "name": "pin1",
     "pin_number": 1,
-    "port_hints": [
-      "pin1",
-      "anode",
-      "pos",
-      "left",
-      "1"
-    ],
+    "port_hints": ["pin1", "anode", "pos", "left", "1"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net6"
@@ -1512,13 +1229,7 @@
     "source_port_id": "source_port_38",
     "name": "pin2",
     "pin_number": 2,
-    "port_hints": [
-      "pin2",
-      "cathode",
-      "neg",
-      "right",
-      "2"
-    ],
+    "port_hints": ["pin2", "cathode", "neg", "right", "2"],
     "source_component_id": "source_component_7",
     "subcircuit_id": "subcircuit_source_group_2",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1531,11 +1242,7 @@
     "color": "green",
     "symbol_display_value": "green",
     "supplier_part_numbers": {
-      "jlcpcb": [
-        "C84263",
-        "C965799",
-        "C84267"
-      ]
+      "jlcpcb": ["C84263", "C965799", "C84267"]
     },
     "are_pins_interchangeable": false,
     "source_group_id": "source_group_1"
@@ -1609,12 +1316,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_0",
-    "connected_source_port_ids": [
-      "source_port_8"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_8"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "chip.U1 > port.VDD to net.VDD",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
@@ -1622,12 +1325,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_1",
-    "connected_source_port_ids": [
-      "source_port_6"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_6"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "chip.U1 > port.VSS to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1635,12 +1334,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_2",
-    "connected_source_port_ids": [
-      "source_port_1"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_1"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "chip.U1 > port.pin2 to net.BOARD_TX",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
@@ -1648,12 +1343,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_3",
-    "connected_source_port_ids": [
-      "source_port_2"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_2"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "chip.U1 > port.pin3 to net.BOARD_RX",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
@@ -1661,12 +1352,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_4",
-    "connected_source_port_ids": [
-      "source_port_3"
-    ],
-    "connected_source_net_ids": [
-      "source_net_4"
-    ],
+    "connected_source_port_ids": ["source_port_3"],
+    "connected_source_net_ids": ["source_net_4"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "chip.U1 > port.pin4 to net.RST",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
@@ -1674,12 +1361,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_5",
-    "connected_source_port_ids": [
-      "source_port_17"
-    ],
-    "connected_source_net_ids": [
-      "source_net_5"
-    ],
+    "connected_source_port_ids": ["source_port_17"],
+    "connected_source_net_ids": ["source_net_5"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "chip.U1 > port.pin18 to net.SWIO",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
@@ -1687,12 +1370,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_6",
-    "connected_source_port_ids": [
-      "source_port_20"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_20"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "jumper.J1 > port.pin1 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1700,12 +1379,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_7",
-    "connected_source_port_ids": [
-      "source_port_21"
-    ],
-    "connected_source_net_ids": [
-      "source_net_4"
-    ],
+    "connected_source_port_ids": ["source_port_21"],
+    "connected_source_net_ids": ["source_net_4"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "jumper.J1 > port.pin2 to net.RST",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
@@ -1713,12 +1388,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_8",
-    "connected_source_port_ids": [
-      "source_port_22"
-    ],
-    "connected_source_net_ids": [
-      "source_net_5"
-    ],
+    "connected_source_port_ids": ["source_port_22"],
+    "connected_source_net_ids": ["source_net_5"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "jumper.J1 > port.pin3 to net.SWIO",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
@@ -1726,12 +1397,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_9",
-    "connected_source_port_ids": [
-      "source_port_23"
-    ],
-    "connected_source_net_ids": [
-      "source_net_2"
-    ],
+    "connected_source_port_ids": ["source_port_23"],
+    "connected_source_net_ids": ["source_net_2"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "jumper.J1 > port.pin4 to net.BOARD_TX",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
@@ -1739,12 +1406,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_10",
-    "connected_source_port_ids": [
-      "source_port_24"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_24"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "jumper.J1 > port.pin5 to net.BOARD_RX",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
@@ -1752,12 +1415,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_11",
-    "connected_source_port_ids": [
-      "source_port_25"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_25"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "resistor.R1 > port.pos to net.VDD",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
@@ -1765,12 +1424,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_12",
-    "connected_source_port_ids": [
-      "source_port_26"
-    ],
-    "connected_source_net_ids": [
-      "source_net_3"
-    ],
+    "connected_source_port_ids": ["source_port_26"],
+    "connected_source_net_ids": ["source_net_3"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "resistor.R1 > port.neg to net.BOARD_RX",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
@@ -1778,12 +1433,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_13",
-    "connected_source_port_ids": [
-      "source_port_27"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_27"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_2",
     "max_length": null,
     "display_name": "capacitor.C1 > port.anode to net.VDD",
@@ -1792,12 +1443,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_14",
-    "connected_source_port_ids": [
-      "source_port_28"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_28"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_2",
     "max_length": null,
     "display_name": "capacitor.C1 > port.cathode to net.GND",
@@ -1806,12 +1453,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_15",
-    "connected_source_port_ids": [
-      "source_port_29"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_29"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": ".SW1 > .pin1 to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -1819,12 +1462,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_16",
-    "connected_source_port_ids": [
-      "source_port_30"
-    ],
-    "connected_source_net_ids": [
-      "source_net_4"
-    ],
+    "connected_source_port_ids": ["source_port_30"],
+    "connected_source_net_ids": ["source_net_4"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": ".SW1 > .pin2 to net.RST",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
@@ -1832,12 +1471,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_17",
-    "connected_source_port_ids": [
-      "source_port_33"
-    ],
-    "connected_source_net_ids": [
-      "source_net_4"
-    ],
+    "connected_source_port_ids": ["source_port_33"],
+    "connected_source_net_ids": ["source_net_4"],
     "subcircuit_id": "subcircuit_source_group_2",
     "max_length": null,
     "display_name": "group.reset_button > capacitor.C2 > port.anode to net.RST",
@@ -1846,12 +1481,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_18",
-    "connected_source_port_ids": [
-      "source_port_34"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_34"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_2",
     "max_length": null,
     "display_name": "group.reset_button > capacitor.C2 > port.cathode to net.GND",
@@ -1860,12 +1491,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_19",
-    "connected_source_port_ids": [
-      "source_port_35"
-    ],
-    "connected_source_net_ids": [
-      "source_net_0"
-    ],
+    "connected_source_port_ids": ["source_port_35"],
+    "connected_source_net_ids": ["source_net_0"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "group.power_led > resistor.R2 > port.pos to net.VDD",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
@@ -1873,10 +1500,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_20",
-    "connected_source_port_ids": [
-      "source_port_36",
-      "source_port_37"
-    ],
+    "connected_source_port_ids": ["source_port_36", "source_port_37"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "group.power_led > resistor.R2 > port.neg to .LED_PWR > .pos",
@@ -1885,10 +1509,7 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_21",
-    "connected_source_port_ids": [
-      "source_port_37",
-      "source_port_36"
-    ],
+    "connected_source_port_ids": ["source_port_37", "source_port_36"],
     "connected_source_net_ids": [],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "group.power_led > led.LED_PWR > port.pos to .R2 > .neg",
@@ -1897,12 +1518,8 @@
   {
     "type": "source_trace",
     "source_trace_id": "source_trace_22",
-    "connected_source_port_ids": [
-      "source_port_38"
-    ],
-    "connected_source_net_ids": [
-      "source_net_1"
-    ],
+    "connected_source_port_ids": ["source_port_38"],
+    "connected_source_net_ids": ["source_net_1"],
     "subcircuit_id": "subcircuit_source_group_2",
     "display_name": "group.power_led > led.LED_PWR > port.neg to net.GND",
     "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
@@ -4253,9 +3870,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_0",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4266,9 +3881,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_1",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4279,9 +3892,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_2",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4292,9 +3903,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_3",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4305,9 +3914,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_4",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4318,9 +3925,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_5",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4331,9 +3936,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_6",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4344,9 +3947,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_7",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4357,9 +3958,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_8",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4370,9 +3969,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_9",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 2.870961999999963,
@@ -4383,9 +3980,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_10",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4396,9 +3991,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_11",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4409,9 +4002,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_12",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4422,9 +4013,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_13",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4435,9 +4024,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_14",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4448,9 +4035,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_15",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4461,9 +4046,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_16",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4474,9 +4057,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_17",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4487,9 +4068,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_18",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4500,9 +4079,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_19",
     "pcb_component_id": "pcb_component_0",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.870961999999963,
@@ -4513,12 +4090,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_20",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": -2.08,
@@ -4529,12 +4101,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_21",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 0.45999999999999996,
@@ -4545,12 +4112,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_22",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 3,
@@ -4561,12 +4123,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_23",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 5.54,
@@ -4577,12 +4134,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_24",
     "pcb_component_id": "pcb_component_1",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 8.08,
@@ -4593,9 +4145,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_25",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 10,
@@ -4606,9 +4156,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_26",
     "pcb_component_id": "pcb_component_2",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 10,
@@ -4619,9 +4167,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_27",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 7,
@@ -4632,9 +4178,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_28",
     "pcb_component_id": "pcb_component_3",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_2",
     "x": 7,
@@ -4645,12 +4189,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_29",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0",
     "x": -1.2499299999999494,
@@ -4661,12 +4200,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_30",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0",
     "x": 5.249929999999836,
@@ -4677,12 +4211,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_31",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0",
     "x": -1.2499299999999494,
@@ -4693,12 +4222,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_32",
     "pcb_component_id": "pcb_component_4",
-    "layers": [
-      "top",
-      "inner1",
-      "inner2",
-      "bottom"
-    ],
+    "layers": ["top", "inner1", "inner2", "bottom"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0",
     "x": 5.249929999999836,
@@ -4709,9 +4233,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_33",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0",
     "x": 2.825,
@@ -4722,9 +4244,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_34",
     "pcb_component_id": "pcb_component_5",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_0",
     "x": 1.175,
@@ -4735,9 +4255,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_35",
     "pcb_component_id": "pcb_component_6",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_1",
     "x": 8.175,
@@ -4748,9 +4266,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_36",
     "pcb_component_id": "pcb_component_6",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_1",
     "x": 9.825,
@@ -4761,9 +4277,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_37",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_1",
     "x": 9.825,
@@ -4774,9 +4288,7 @@
     "type": "pcb_port",
     "pcb_port_id": "pcb_port_38",
     "pcb_component_id": "pcb_component_7",
-    "layers": [
-      "top"
-    ],
+    "layers": ["top"],
     "subcircuit_id": "subcircuit_source_group_2",
     "pcb_group_id": "pcb_group_1",
     "x": 8.175,
@@ -6158,10 +5670,7 @@
     "y": 5.15626093749999,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -6173,10 +5682,7 @@
     "y": 3.3593914062499852,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -6188,10 +5694,7 @@
     "y": -6.779976355366476,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -6203,10 +5706,7 @@
     "y": -7.43641776525784,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -6218,10 +5718,7 @@
     "y": -0.5937215625000236,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -6233,10 +5730,7 @@
     "y": 2.2983827306547453,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -6248,10 +5742,7 @@
     "y": 5.15626093749999,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -6263,10 +5754,7 @@
     "y": 2.3000000000000003,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -6278,10 +5766,7 @@
     "y": 5.15626093749999,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -6293,10 +5778,7 @@
     "y": -0.5937215625000236,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -6308,10 +5790,7 @@
     "y": 1.2031479687499806,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -6323,10 +5802,7 @@
     "y": 2.281269687499983,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   },
@@ -6338,10 +5814,7 @@
     "y": 2.281269687499983,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "top",
-      "bottom"
-    ],
+    "layers": ["top", "bottom"],
     "from_layer": "top",
     "to_layer": "bottom"
   },
@@ -6353,10 +5826,7 @@
     "y": -2.3000000000000007,
     "hole_diameter": 0.3,
     "outer_diameter": 0.6,
-    "layers": [
-      "bottom",
-      "top"
-    ],
+    "layers": ["bottom", "top"],
     "from_layer": "bottom",
     "to_layer": "top"
   }

--- a/tests/assets/repro-trace-disconnection.json
+++ b/tests/assets/repro-trace-disconnection.json
@@ -1,0 +1,6363 @@
+[
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_0",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_20",
+    "hole_diameter": 1,
+    "rect_pad_width": 1.5,
+    "rect_pad_height": 1.5,
+    "shape": "circular_hole_with_rect_pad",
+    "port_hints": [
+      "unnamed_platedhole1",
+      "1"
+    ],
+    "x": -2.08,
+    "y": 7,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "rect_border_radius": 0
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_1",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_21",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole2",
+      "2"
+    ],
+    "x": 0.45999999999999996,
+    "y": 7,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_2",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_22",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole3",
+      "3"
+    ],
+    "x": 3,
+    "y": 7,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_3",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_23",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole4",
+      "4"
+    ],
+    "x": 5.54,
+    "y": 7,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_4",
+    "pcb_component_id": "pcb_component_1",
+    "pcb_port_id": "pcb_port_24",
+    "outer_diameter": 1.5,
+    "hole_diameter": 1,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole5",
+      "5"
+    ],
+    "x": 8.08,
+    "y": 7,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_5",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_32",
+    "outer_diameter": 1.9999959999999999,
+    "hole_diameter": 1.3000228,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole6",
+      "4"
+    ],
+    "x": 5.249929999999836,
+    "y": -12.249932000000058,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_6",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_30",
+    "outer_diameter": 1.9999959999999999,
+    "hole_diameter": 1.3000228,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole7",
+      "2"
+    ],
+    "x": 5.249929999999836,
+    "y": -7.750067999999942,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_7",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_29",
+    "outer_diameter": 1.9999959999999999,
+    "hole_diameter": 1.3000228,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole8",
+      "1"
+    ],
+    "x": -1.2499299999999494,
+    "y": -7.750067999999942,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_plated_hole",
+    "pcb_plated_hole_id": "pcb_plated_hole_8",
+    "pcb_component_id": "pcb_component_4",
+    "pcb_port_id": "pcb_port_31",
+    "outer_diameter": 1.9999959999999999,
+    "hole_diameter": 1.3000228,
+    "shape": "circle",
+    "port_hints": [
+      "unnamed_platedhole9",
+      "3"
+    ],
+    "x": -1.2499299999999494,
+    "y": -12.249932000000058,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_0",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin1"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": -2.925064000000134,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_1",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin2"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": -2.2750780000000077,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_2",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin3"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": -1.625092000000109,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_3",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin4"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": -0.9751059999999827,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin5"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": -0.3248660000000429,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin6"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": 0.3251200000000834,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin7"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": 0.9751059999999823,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin8"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": 1.6250919999999949,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin9"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": 2.2750780000000077,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin10"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.870961999999963,
+    "y": 2.9250640000000203,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin20"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": -2.925064000000134,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin19"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": -2.2750780000000077,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin18"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": -1.6250920000001086,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin17"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": -0.9751059999999823,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin16"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": -0.32486600000004257,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin15"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": 0.32512000000008373,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin14"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": 0.9751059999999827,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin13"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": 1.6250919999999953,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin12"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": 2.2750780000000077,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "pcb_component_id": "pcb_component_0",
+    "pcb_port_id": "pcb_port_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.7420082,
+    "height": 0.3640074,
+    "port_hints": [
+      "pin11"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": -2.870961999999963,
+    "y": 2.9250640000000203,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_25",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.95,
+    "height": 0.8,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 10,
+    "y": 2.825,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "pcb_component_id": "pcb_component_2",
+    "pcb_port_id": "pcb_port_26",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.95,
+    "height": 0.8,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 10,
+    "y": 1.175,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_27",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.95,
+    "height": 0.8,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7,
+    "y": 2.825,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "pcb_component_id": "pcb_component_3",
+    "pcb_port_id": "pcb_port_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.95,
+    "height": 0.8,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 7,
+    "y": 1.175,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_33",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 2.825,
+    "y": -5,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "pcb_component_id": "pcb_component_5",
+    "pcb_port_id": "pcb_port_34",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 1.175,
+    "y": -5,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_35",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 8.175,
+    "y": -3,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "pcb_component_id": "pcb_component_6",
+    "pcb_port_id": "pcb_port_36",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.825,
+    "y": -3,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_37",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 9.825,
+    "y": -6,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "pcb_component_id": "pcb_component_7",
+    "pcb_port_id": "pcb_port_38",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.8,
+    "height": 0.95,
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "is_covered_with_solder_mask": false,
+    "x": 8.175,
+    "y": -6,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_0",
+    "center": {
+      "x": 0,
+      "y": -5.684341886080802e-14
+    },
+    "width": 6.1059313999999265,
+    "height": 7.592136200000154,
+    "layer": "top",
+    "rotation": 90,
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_1",
+    "center": {
+      "x": 3,
+      "y": 7
+    },
+    "width": 11.66,
+    "height": 1.5,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_2",
+    "center": {
+      "x": 10,
+      "y": 2
+    },
+    "width": 0.8000000000000007,
+    "height": 2.6,
+    "layer": "top",
+    "rotation": -90,
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_3",
+    "center": {
+      "x": 7,
+      "y": 2
+    },
+    "width": 0.8000000000000007,
+    "height": 2.6,
+    "layer": "top",
+    "rotation": -90,
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_4",
+    "center": {
+      "x": 1.9999999999999432,
+      "y": -10
+    },
+    "width": 8.499855999999784,
+    "height": 6.499860000000115,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_5",
+    "center": {
+      "x": 2,
+      "y": -5
+    },
+    "width": 2.45,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 180,
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_6",
+    "center": {
+      "x": 9,
+      "y": -3
+    },
+    "width": 2.4499999999999993,
+    "height": 0.9500000000000002,
+    "layer": "top",
+    "rotation": 0,
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_component",
+    "pcb_component_id": "pcb_component_7",
+    "center": {
+      "x": 9,
+      "y": -6
+    },
+    "width": 2.4499999999999993,
+    "height": 0.9499999999999993,
+    "layer": "top",
+    "rotation": 180,
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "do_not_place": false,
+    "obstructs_within_bounds": true,
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "source_project_metadata",
+    "source_project_metadata_id": "source_project_metadata_0",
+    "software_used_string": "@tscircuit/core@0.0.753"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_0",
+    "name": "reset_button",
+    "parent_source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_1",
+    "name": "power_led",
+    "parent_source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_group",
+    "source_group_id": "source_group_2",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_0",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_1",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_2",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_3",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "name": "pin6",
+    "pin_number": 6,
+    "port_hints": [
+      "pin6",
+      "6"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "name": "VSS",
+    "pin_number": 7,
+    "port_hints": [
+      "VSS",
+      "pin7",
+      "7"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "name": "pin8",
+    "pin_number": 8,
+    "port_hints": [
+      "pin8",
+      "8"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_8",
+    "name": "VDD",
+    "pin_number": 9,
+    "port_hints": [
+      "VDD",
+      "pin9",
+      "9"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_9",
+    "name": "pin10",
+    "pin_number": 10,
+    "port_hints": [
+      "pin10",
+      "10"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_10",
+    "name": "pin11",
+    "pin_number": 11,
+    "port_hints": [
+      "pin11",
+      "11"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_11",
+    "name": "pin12",
+    "pin_number": 12,
+    "port_hints": [
+      "pin12",
+      "12"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_12",
+    "name": "pin13",
+    "pin_number": 13,
+    "port_hints": [
+      "pin13",
+      "13"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_13",
+    "name": "pin14",
+    "pin_number": 14,
+    "port_hints": [
+      "pin14",
+      "14"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_14",
+    "name": "pin15",
+    "pin_number": 15,
+    "port_hints": [
+      "pin15",
+      "15"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_15",
+    "name": "pin16",
+    "pin_number": 16,
+    "port_hints": [
+      "pin16",
+      "16"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_16",
+    "name": "pin17",
+    "pin_number": 17,
+    "port_hints": [
+      "pin17",
+      "17"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_17",
+    "name": "pin18",
+    "pin_number": 18,
+    "port_hints": [
+      "pin18",
+      "18"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_18",
+    "name": "pin19",
+    "pin_number": 19,
+    "port_hints": [
+      "pin19",
+      "19"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_19",
+    "name": "pin20",
+    "pin_number": 20,
+    "port_hints": [
+      "pin20",
+      "20"
+    ],
+    "source_component_id": "source_component_0",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_0",
+    "ftype": "simple_chip",
+    "name": "U1",
+    "manufacturer_part_number": "CH32V003F4P6",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C5187096"
+      ]
+    },
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_20",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_21",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_22",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_23",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_24",
+    "name": "pin5",
+    "pin_number": 5,
+    "port_hints": [
+      "pin5",
+      "5"
+    ],
+    "source_component_id": "source_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_1",
+    "ftype": "simple_chip",
+    "name": "J1",
+    "supplier_part_numbers": {
+      "jlcpcb": []
+    },
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_25",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_26",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_2",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_2",
+    "ftype": "simple_resistor",
+    "name": "R1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C25803",
+        "C2907088",
+        "C2906980"
+      ]
+    },
+    "resistance": 100000,
+    "display_resistance": "100kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_27",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_28",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2"
+    ],
+    "source_component_id": "source_component_3",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_3",
+    "ftype": "simple_capacitor",
+    "name": "C1",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C14663",
+        "C30926",
+        "C1591"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100n",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_29",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "1"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_30",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "2"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_31",
+    "name": "pin3",
+    "pin_number": 3,
+    "port_hints": [
+      "pin3",
+      "3"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_32",
+    "name": "pin4",
+    "pin_number": 4,
+    "port_hints": [
+      "pin4",
+      "4"
+    ],
+    "source_component_id": "source_component_4",
+    "subcircuit_id": "subcircuit_source_group_2"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_4",
+    "name": "SW1",
+    "ftype": "simple_push_button",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C110153"
+      ]
+    },
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_33",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "pos",
+      "anode",
+      "1"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_34",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "neg",
+      "cathode",
+      "2"
+    ],
+    "source_component_id": "source_component_5",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_5",
+    "ftype": "simple_capacitor",
+    "name": "C2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C14663",
+        "C30926",
+        "C1591"
+      ]
+    },
+    "capacitance": 1e-7,
+    "display_capacitance": "100n",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_35",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_36",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_6",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net6"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_6",
+    "ftype": "simple_resistor",
+    "name": "R2",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C21190",
+        "C25585",
+        "C115325"
+      ]
+    },
+    "resistance": 1000,
+    "display_resistance": "1kΩ",
+    "are_pins_interchangeable": true,
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_37",
+    "name": "pin1",
+    "pin_number": 1,
+    "port_hints": [
+      "pin1",
+      "anode",
+      "pos",
+      "left",
+      "1"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net6"
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_38",
+    "name": "pin2",
+    "pin_number": 2,
+    "port_hints": [
+      "pin2",
+      "cathode",
+      "neg",
+      "right",
+      "2"
+    ],
+    "source_component_id": "source_component_7",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "source_component_7",
+    "ftype": "simple_led",
+    "name": "LED_PWR",
+    "color": "green",
+    "symbol_display_value": "green",
+    "supplier_part_numbers": {
+      "jlcpcb": [
+        "C84263",
+        "C965799",
+        "C84267"
+      ]
+    },
+    "are_pins_interchangeable": false,
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_0",
+    "name": "VDD",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": true,
+    "is_positive_voltage_source": true,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_1",
+    "name": "GND",
+    "member_source_group_ids": [],
+    "is_ground": true,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_2",
+    "name": "BOARD_TX",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_3",
+    "name": "BOARD_RX",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_4",
+    "name": "RST",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_net",
+    "source_net_id": "source_net_5",
+    "name": "SWIO",
+    "member_source_group_ids": [],
+    "is_ground": false,
+    "is_power": false,
+    "is_positive_voltage_source": false,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_0",
+    "connected_source_port_ids": [
+      "source_port_8"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "chip.U1 > port.VDD to net.VDD",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_1",
+    "connected_source_port_ids": [
+      "source_port_6"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "chip.U1 > port.VSS to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_2",
+    "connected_source_port_ids": [
+      "source_port_1"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "chip.U1 > port.pin2 to net.BOARD_TX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_3",
+    "connected_source_port_ids": [
+      "source_port_2"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "chip.U1 > port.pin3 to net.BOARD_RX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_4",
+    "connected_source_port_ids": [
+      "source_port_3"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "chip.U1 > port.pin4 to net.RST",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_5",
+    "connected_source_port_ids": [
+      "source_port_17"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "chip.U1 > port.pin18 to net.SWIO",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_6",
+    "connected_source_port_ids": [
+      "source_port_20"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "jumper.J1 > port.pin1 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_7",
+    "connected_source_port_ids": [
+      "source_port_21"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "jumper.J1 > port.pin2 to net.RST",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_8",
+    "connected_source_port_ids": [
+      "source_port_22"
+    ],
+    "connected_source_net_ids": [
+      "source_net_5"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "jumper.J1 > port.pin3 to net.SWIO",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net5"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_9",
+    "connected_source_port_ids": [
+      "source_port_23"
+    ],
+    "connected_source_net_ids": [
+      "source_net_2"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "jumper.J1 > port.pin4 to net.BOARD_TX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net2"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_10",
+    "connected_source_port_ids": [
+      "source_port_24"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "jumper.J1 > port.pin5 to net.BOARD_RX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_11",
+    "connected_source_port_ids": [
+      "source_port_25"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "resistor.R1 > port.pos to net.VDD",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_12",
+    "connected_source_port_ids": [
+      "source_port_26"
+    ],
+    "connected_source_net_ids": [
+      "source_net_3"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "resistor.R1 > port.neg to net.BOARD_RX",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_13",
+    "connected_source_port_ids": [
+      "source_port_27"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "max_length": null,
+    "display_name": "capacitor.C1 > port.anode to net.VDD",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_14",
+    "connected_source_port_ids": [
+      "source_port_28"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "max_length": null,
+    "display_name": "capacitor.C1 > port.cathode to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_15",
+    "connected_source_port_ids": [
+      "source_port_29"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": ".SW1 > .pin1 to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_16",
+    "connected_source_port_ids": [
+      "source_port_30"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": ".SW1 > .pin2 to net.RST",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_17",
+    "connected_source_port_ids": [
+      "source_port_33"
+    ],
+    "connected_source_net_ids": [
+      "source_net_4"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "max_length": null,
+    "display_name": "group.reset_button > capacitor.C2 > port.anode to net.RST",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net4"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_18",
+    "connected_source_port_ids": [
+      "source_port_34"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "max_length": null,
+    "display_name": "group.reset_button > capacitor.C2 > port.cathode to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_19",
+    "connected_source_port_ids": [
+      "source_port_35"
+    ],
+    "connected_source_net_ids": [
+      "source_net_0"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "group.power_led > resistor.R2 > port.pos to net.VDD",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_20",
+    "connected_source_port_ids": [
+      "source_port_36",
+      "source_port_37"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "group.power_led > resistor.R2 > port.neg to .LED_PWR > .pos",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_21",
+    "connected_source_port_ids": [
+      "source_port_37",
+      "source_port_36"
+    ],
+    "connected_source_net_ids": [],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "group.power_led > led.LED_PWR > port.pos to .R2 > .neg",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net6"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_22",
+    "connected_source_port_ids": [
+      "source_port_38"
+    ],
+    "connected_source_net_ids": [
+      "source_net_1"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "display_name": "group.power_led > led.LED_PWR > port.neg to net.GND",
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "source_pin_missing_trace_warning",
+    "source_pin_missing_trace_warning_id": "source_pin_missing_trace_warning_0",
+    "message": "Port pin3 on SW1 is missing a trace",
+    "source_component_id": "source_component_4",
+    "source_port_id": "source_port_31",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "warning_type": "source_pin_missing_trace_warning"
+  },
+  {
+    "type": "source_pin_missing_trace_warning",
+    "source_pin_missing_trace_warning_id": "source_pin_missing_trace_warning_1",
+    "message": "Port pin4 on SW1 is missing a trace",
+    "source_component_id": "source_component_4",
+    "source_port_id": "source_port_32",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "warning_type": "source_pin_missing_trace_warning"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "rotation": 0,
+    "size": {
+      "width": 1.2000000000000002,
+      "height": 2.1999999999999997
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {
+      "pin1": "pin1",
+      "pin2": "pin2",
+      "pin3": "pin3",
+      "pin4": "pin4",
+      "pin5": "pin5",
+      "pin6": "pin6",
+      "pin7": "VSS",
+      "pin8": "pin8",
+      "pin9": "VDD",
+      "pin10": "pin10",
+      "pin11": "pin11",
+      "pin12": "pin12",
+      "pin13": "pin13",
+      "pin14": "pin14",
+      "pin15": "pin15",
+      "pin16": "pin16",
+      "pin17": "pin17",
+      "pin18": "pin18",
+      "pin19": "pin19",
+      "pin20": "pin20"
+    },
+    "source_component_id": "source_component_0",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "text": "CH32V003F4P6",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": -1.23
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "text": "U1",
+    "schematic_component_id": "schematic_component_0",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.6000000000000001,
+      "y": 1.23
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -2,
+      "y": 3.1049999999999995
+    },
+    "rotation": 0,
+    "size": {
+      "width": 0.4,
+      "height": 1.2000000000000002
+    },
+    "port_arrangement": {
+      "left_size": 0,
+      "right_size": 5
+    },
+    "pin_spacing": 0.2,
+    "port_labels": {},
+    "source_component_id": "source_component_1",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_2",
+    "text": "",
+    "schematic_component_id": "schematic_component_1",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -2.2,
+      "y": 2.3749999999999996
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_3",
+    "text": "J1",
+    "schematic_component_id": "schematic_component_1",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -2.2,
+      "y": 3.8349999999999995
+    },
+    "color": "#006464",
+    "font_size": 0.18
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -2.7600000000000002,
+      "y": 0.7105446499999999
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_2",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "100kΩ",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -2.7600000000000002,
+      "y": -1.1039106999999992
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_3",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100n",
+    "schematic_group_id": "schematic_group_2"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "size": {
+      "width": 1,
+      "height": 0.45
+    },
+    "source_component_id": "source_component_4",
+    "is_box_with_pins": true,
+    "symbol_name": "push_button_normally_open_momentary_horz",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": 0,
+      "y": -1.845
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.84
+    },
+    "source_component_id": "source_component_5",
+    "is_box_with_pins": true,
+    "symbol_name": "capacitor_right",
+    "symbol_display_value": "100n",
+    "schematic_group_id": "schematic_group_0"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_0",
+    "subcircuit_id": null,
+    "name": "reset_button",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "size": {
+      "width": 1.1,
+      "height": 0.388910699999999
+    },
+    "source_component_id": "source_component_6",
+    "is_box_with_pins": true,
+    "symbol_name": "boxresistor_right",
+    "symbol_display_value": "1kΩ",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_component",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1.7900000000000003,
+      "y": 0
+    },
+    "size": {
+      "width": 1.13,
+      "height": 0.65
+    },
+    "source_component_id": "source_component_7",
+    "is_box_with_pins": true,
+    "symbol_name": "led_right",
+    "symbol_display_value": "green",
+    "schematic_group_id": "schematic_group_1"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_1",
+    "subcircuit_id": null,
+    "name": "power_led",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "schematic_group",
+    "schematic_group_id": "schematic_group_2",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "name": "unnamed_group1",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 0,
+    "height": 0,
+    "schematic_component_ids": [],
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.8999999999999999
+    },
+    "source_port_id": "source_port_0",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.7
+    },
+    "source_port_id": "source_port_1",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.4999999999999999
+    },
+    "source_port_id": "source_port_2",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.2999999999999998
+    },
+    "source_port_id": "source_port_3",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": 0.09999999999999987
+    },
+    "source_port_id": "source_port_4",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.10000000000000009
+    },
+    "source_port_id": "source_port_5",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 6,
+    "true_ccw_index": 5,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.30000000000000004
+    },
+    "source_port_id": "source_port_6",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 7,
+    "true_ccw_index": 6,
+    "display_pin_label": "VSS",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.5
+    },
+    "source_port_id": "source_port_7",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 8,
+    "true_ccw_index": 7,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.7
+    },
+    "source_port_id": "source_port_8",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 9,
+    "true_ccw_index": 8,
+    "display_pin_label": "VDD",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": -1,
+      "y": -0.8999999999999999
+    },
+    "source_port_id": "source_port_9",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "left",
+    "pin_number": 10,
+    "true_ccw_index": 9,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_10",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.8999999999999999
+    },
+    "source_port_id": "source_port_10",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 11,
+    "true_ccw_index": 10,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_11",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.7
+    },
+    "source_port_id": "source_port_11",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 12,
+    "true_ccw_index": 11,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_12",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.4999999999999999
+    },
+    "source_port_id": "source_port_12",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 13,
+    "true_ccw_index": 12,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_13",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.2999999999999998
+    },
+    "source_port_id": "source_port_13",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 14,
+    "true_ccw_index": 13,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_14",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": -0.09999999999999987
+    },
+    "source_port_id": "source_port_14",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 15,
+    "true_ccw_index": 14,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_15",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.10000000000000009
+    },
+    "source_port_id": "source_port_15",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 16,
+    "true_ccw_index": 15,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_16",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.30000000000000004
+    },
+    "source_port_id": "source_port_16",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 17,
+    "true_ccw_index": 16,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_17",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.5
+    },
+    "source_port_id": "source_port_17",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 18,
+    "true_ccw_index": 17,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_18",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.7
+    },
+    "source_port_id": "source_port_18",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 19,
+    "true_ccw_index": 18,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_19",
+    "schematic_component_id": "schematic_component_0",
+    "center": {
+      "x": 1,
+      "y": 0.8999999999999999
+    },
+    "source_port_id": "source_port_19",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 20,
+    "true_ccw_index": 19,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_20",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1.4,
+      "y": 2.7049999999999996
+    },
+    "source_port_id": "source_port_20",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 1,
+    "true_ccw_index": 0,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_21",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1.4,
+      "y": 2.9049999999999994
+    },
+    "source_port_id": "source_port_21",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 2,
+    "true_ccw_index": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_22",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1.4,
+      "y": 3.1049999999999995
+    },
+    "source_port_id": "source_port_22",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 3,
+    "true_ccw_index": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_23",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1.4,
+      "y": 3.3049999999999997
+    },
+    "source_port_id": "source_port_23",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 4,
+    "true_ccw_index": 3,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_24",
+    "schematic_component_id": "schematic_component_1",
+    "center": {
+      "x": -1.4,
+      "y": 3.5049999999999994
+    },
+    "source_port_id": "source_port_24",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "side_of_component": "right",
+    "pin_number": 5,
+    "true_ccw_index": 4,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_25",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -3.3100000000000005,
+      "y": 0.7105446499999999
+    },
+    "source_port_id": "source_port_25",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_26",
+    "schematic_component_id": "schematic_component_2",
+    "center": {
+      "x": -2.21,
+      "y": 0.7105446499999999
+    },
+    "source_port_id": "source_port_26",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_27",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -3.3100000000000005,
+      "y": -1.1039106999999992
+    },
+    "source_port_id": "source_port_27",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_28",
+    "schematic_component_id": "schematic_component_3",
+    "center": {
+      "x": -2.21,
+      "y": -1.1039106999999992
+    },
+    "source_port_id": "source_port_28",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": true
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_29",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": -0.47,
+      "y": -0.05
+    },
+    "source_port_id": "source_port_29",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_30",
+    "schematic_component_id": "schematic_component_4",
+    "center": {
+      "x": 0.47,
+      "y": -0.05
+    },
+    "source_port_id": "source_port_30",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_31",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": -0.55,
+      "y": -1.845
+    },
+    "source_port_id": "source_port_33",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "pos",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_32",
+    "schematic_component_id": "schematic_component_5",
+    "center": {
+      "x": 0.55,
+      "y": -1.845
+    },
+    "source_port_id": "source_port_34",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "neg",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_33",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": -0.55,
+      "y": 0
+    },
+    "source_port_id": "source_port_35",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_34",
+    "schematic_component_id": "schematic_component_6",
+    "center": {
+      "x": 0.55,
+      "y": 0
+    },
+    "source_port_id": "source_port_36",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_35",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 1.2500000000000002,
+      "y": 0
+    },
+    "source_port_id": "source_port_37",
+    "facing_direction": "left",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 1,
+    "display_pin_label": "anode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_36",
+    "schematic_component_id": "schematic_component_7",
+    "center": {
+      "x": 2.33,
+      "y": 0
+    },
+    "source_port_id": "source_port_38",
+    "facing_direction": "right",
+    "distance_from_component_edge": 0.4,
+    "pin_number": 2,
+    "display_pin_label": "cathode",
+    "is_connected": false
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_0",
+    "source_trace_id": "solver_U1.3-R1.2",
+    "edges": [
+      {
+        "from": {
+          "x": -1,
+          "y": 0.4999999999999999
+        },
+        "to": {
+          "x": -1.605,
+          "y": 0.4999999999999999
+        }
+      },
+      {
+        "from": {
+          "x": -1.605,
+          "y": 0.4999999999999999
+        },
+        "to": {
+          "x": -1.605,
+          "y": 0.7105446499999999
+        }
+      },
+      {
+        "from": {
+          "x": -1.605,
+          "y": 0.7105446499999999
+        },
+        "to": {
+          "x": -2.21,
+          "y": 0.7105446499999999
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net3"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_1",
+    "source_trace_id": "solver_U1.7-C1.2",
+    "edges": [
+      {
+        "from": {
+          "x": -1,
+          "y": -0.30000000000000004
+        },
+        "to": {
+          "x": -1.605,
+          "y": -0.30000000000000004
+        }
+      },
+      {
+        "from": {
+          "x": -1.605,
+          "y": -0.30000000000000004
+        },
+        "to": {
+          "x": -1.605,
+          "y": -1.1039106999999992
+        }
+      },
+      {
+        "from": {
+          "x": -1.605,
+          "y": -1.1039106999999992
+        },
+        "to": {
+          "x": -2.21,
+          "y": -1.1039106999999992
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net1"
+  },
+  {
+    "type": "schematic_trace",
+    "schematic_trace_id": "schematic_trace_2",
+    "source_trace_id": "solver_R1.1-C1.1",
+    "edges": [
+      {
+        "from": {
+          "x": -3.3100000000000005,
+          "y": 0.7105446499999999
+        },
+        "to": {
+          "x": -3.5100000000000007,
+          "y": 0.7105446499999999
+        }
+      },
+      {
+        "from": {
+          "x": -3.5100000000000007,
+          "y": 0.7105446499999999
+        },
+        "to": {
+          "x": -3.5100000000000007,
+          "y": -1.1039106999999992
+        }
+      },
+      {
+        "from": {
+          "x": -3.5100000000000007,
+          "y": -1.1039106999999992
+        },
+        "to": {
+          "x": -3.3100000000000005,
+          "y": -1.1039106999999992
+        }
+      }
+    ],
+    "junctions": [],
+    "subcircuit_connectivity_map_key": "unnamedsubcircuit122_connectivity_net0"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_0",
+    "text": "BOARD_TX",
+    "anchor_position": {
+      "x": -1,
+      "y": 0.7
+    },
+    "center": {
+      "x": -1.4,
+      "y": 0.7
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_1",
+    "text": "BOARD_TX",
+    "anchor_position": {
+      "x": -1.4,
+      "y": 3.3049999999999997
+    },
+    "center": {
+      "x": -0.9999999999999999,
+      "y": 3.3049999999999997
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_2"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_2",
+    "text": "BOARD_RX",
+    "anchor_position": {
+      "x": -1.3025,
+      "y": 0.4999999999999999
+    },
+    "center": {
+      "x": -1.3025,
+      "y": 0.5899999999999999
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_3"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_3",
+    "text": "BOARD_RX",
+    "anchor_position": {
+      "x": -1.4,
+      "y": 3.5049999999999994
+    },
+    "center": {
+      "x": -0.9999999999999999,
+      "y": 3.5049999999999994
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_3"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_4",
+    "text": "RST",
+    "anchor_position": {
+      "x": -1,
+      "y": 0.2999999999999998
+    },
+    "center": {
+      "x": -1.15,
+      "y": 0.2999999999999998
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_4"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_5",
+    "text": "RST",
+    "anchor_position": {
+      "x": -1.4,
+      "y": 2.9049999999999994
+    },
+    "center": {
+      "x": -1.25,
+      "y": 2.9049999999999994
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_4"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_6",
+    "text": "RST",
+    "anchor_position": {
+      "x": 0.5,
+      "y": -0.05
+    },
+    "center": {
+      "x": 0.65,
+      "y": -0.05
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_4"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_7",
+    "text": "RST",
+    "anchor_position": {
+      "x": -0.55,
+      "y": -1.845
+    },
+    "center": {
+      "x": -0.7000000000000001,
+      "y": -1.845
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_4"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_8",
+    "text": "GND",
+    "anchor_position": {
+      "x": -1.605,
+      "y": -1.1039106999999992
+    },
+    "center": {
+      "x": -1.605,
+      "y": -1.1939106999999993
+    },
+    "anchor_side": "top",
+    "source_net_id": "source_net_1",
+    "symbol_name": "rail_down"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_9",
+    "text": "GND",
+    "anchor_position": {
+      "x": -1.4,
+      "y": 2.7049999999999996
+    },
+    "center": {
+      "x": -1.25,
+      "y": 2.7049999999999996
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_10",
+    "text": "GND",
+    "anchor_position": {
+      "x": -0.5,
+      "y": -0.05
+    },
+    "center": {
+      "x": -0.65,
+      "y": -0.05
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_11",
+    "text": "GND",
+    "anchor_position": {
+      "x": 0.55,
+      "y": -1.845
+    },
+    "center": {
+      "x": 0.7000000000000001,
+      "y": -1.845
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_12",
+    "text": "GND",
+    "anchor_position": {
+      "x": 2.3550000000000004,
+      "y": 0
+    },
+    "center": {
+      "x": 2.5050000000000003,
+      "y": 0
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_1"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_13",
+    "text": "VDD",
+    "anchor_position": {
+      "x": -1,
+      "y": -0.7
+    },
+    "center": {
+      "x": -1.15,
+      "y": -0.7
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_0"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_14",
+    "text": "VDD",
+    "anchor_position": {
+      "x": -3.5100000000000007,
+      "y": 0.7105446499999999
+    },
+    "center": {
+      "x": -3.5100000000000007,
+      "y": 0.8005446499999999
+    },
+    "anchor_side": "bottom",
+    "source_net_id": "source_net_0",
+    "symbol_name": "rail_up"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_15",
+    "text": "VDD",
+    "anchor_position": {
+      "x": -0.55,
+      "y": 0
+    },
+    "center": {
+      "x": -0.7000000000000001,
+      "y": 0
+    },
+    "anchor_side": "right",
+    "source_net_id": "source_net_0"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_16",
+    "text": "SWIO",
+    "anchor_position": {
+      "x": 1,
+      "y": 0.5
+    },
+    "center": {
+      "x": 1.2,
+      "y": 0.5
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_5"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_17",
+    "text": "SWIO",
+    "anchor_position": {
+      "x": -1.4,
+      "y": 3.1049999999999995
+    },
+    "center": {
+      "x": -1.2,
+      "y": 3.1049999999999995
+    },
+    "anchor_side": "left",
+    "source_net_id": "source_net_5"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_18",
+    "text": "R2_pin2/LED_PWR_pin1",
+    "anchor_position": {
+      "x": 0.55,
+      "y": 0
+    },
+    "center": {
+      "x": 1.55,
+      "y": 0
+    },
+    "anchor_side": "left"
+  },
+  {
+    "type": "schematic_net_label",
+    "schematic_net_label_id": "schematic_net_label_19",
+    "text": "R2_pin2/LED_PWR_pin1",
+    "anchor_position": {
+      "x": 1.2250000000000003,
+      "y": 0
+    },
+    "center": {
+      "x": 0.2250000000000003,
+      "y": 0
+    },
+    "anchor_side": "right"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "name": "reset_button",
+    "center": {
+      "x": 1.9999999999999432,
+      "y": -8.887465000000029
+    },
+    "width": 8.499855999999784,
+    "height": 8.724930000000057,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_0"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "name": "power_led",
+    "center": {
+      "x": 9,
+      "y": -4.5
+    },
+    "width": 2.4499999999999993,
+    "height": 3.9499999999999997,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_1"
+  },
+  {
+    "type": "pcb_group",
+    "pcb_group_id": "pcb_group_2",
+    "is_subcircuit": true,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "name": "unnamed_group1",
+    "center": {
+      "x": 3.6735171500000185,
+      "y": -2.749965000000029
+    },
+    "width": 13.452965699999964,
+    "height": 20.999930000000056,
+    "pcb_component_ids": [],
+    "source_group_id": "source_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_0",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": -2.925064000000134,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_1",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": -2.2750780000000077,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_2",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": -1.625092000000109,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_3",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": -0.9751059999999827,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_4",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": -0.3248660000000429,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_5",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": 0.3251200000000834,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_6",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": 0.9751059999999823,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_7",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": 1.6250919999999949,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_8",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": 2.2750780000000077,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_9",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": 2.870961999999963,
+    "y": 2.9250640000000203,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_10",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": -2.925064000000134,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_11",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": -2.2750780000000077,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_12",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": -1.6250920000001086,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_13",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": -0.9751059999999823,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_14",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": -0.32486600000004257,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_15",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": 0.32512000000008373,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_16",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": 0.9751059999999827,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_17",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": 1.6250919999999953,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_18",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": 2.2750780000000077,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_18",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_19",
+    "layer": "top",
+    "shape": "rect",
+    "width": 1.2194057399999998,
+    "height": 0.25480517999999996,
+    "x": -2.870961999999963,
+    "y": 2.9250640000000203,
+    "pcb_component_id": "pcb_component_0",
+    "pcb_smtpad_id": "pcb_smtpad_19",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_0",
+    "pcb_component_id": "pcb_component_0",
+    "layer": "top",
+    "route": [
+      {
+        "x": 1.771396000000095,
+        "y": -3.326206200000115
+      },
+      {
+        "x": -1.7713959999999818,
+        "y": -3.326206200000115
+      },
+      {
+        "x": -1.7713959999999813,
+        "y": 3.3262061999998878
+      },
+      {
+        "x": 1.7713960000000954,
+        "y": 3.3262061999998878
+      },
+      {
+        "x": 1.771396000000095,
+        "y": -3.326206200000115
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_0",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": -2.08,
+      "y": 8.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "pin1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_20",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 0.45999999999999996,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_21",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 0.45999999999999996,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_1",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 0.45999999999999996,
+      "y": 8.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "pin2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_22",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 3,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_23",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 3,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_2",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 3,
+      "y": 8.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "pin3",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_24",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 5.54,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_25",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 5.54,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_3",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 5.54,
+      "y": 8.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "pin4",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_26",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 8.08,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_27",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.75,
+    "x": 8.08,
+    "y": 7,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_4",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 8.08,
+      "y": 8.125
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.5,
+    "layer": "top",
+    "text": "pin5",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_5",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 3,
+      "y": 9.54
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.7,
+    "layer": "top",
+    "text": "J1",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_1",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_28",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649999999999999,
+    "height": 0.5599999999999999,
+    "x": 10,
+    "y": 2.825,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_20",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_29",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649999999999999,
+    "height": 0.5599999999999999,
+    "x": 10,
+    "y": 1.175,
+    "pcb_component_id": "pcb_component_2",
+    "pcb_smtpad_id": "pcb_smtpad_21",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_1",
+    "pcb_component_id": "pcb_component_2",
+    "layer": "top",
+    "route": [
+      {
+        "x": 10.875,
+        "y": 1.175
+      },
+      {
+        "x": 10.875,
+        "y": 3.425
+      },
+      {
+        "x": 9.125,
+        "y": 3.425
+      },
+      {
+        "x": 9.125,
+        "y": 1.175
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_6",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 11.375,
+      "y": 2
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R1",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_2",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_30",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649999999999999,
+    "height": 0.5599999999999999,
+    "x": 7,
+    "y": 2.825,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_22",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_31",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.6649999999999999,
+    "height": 0.5599999999999999,
+    "x": 7,
+    "y": 1.175,
+    "pcb_component_id": "pcb_component_3",
+    "pcb_smtpad_id": "pcb_smtpad_23",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_2",
+    "pcb_component_id": "pcb_component_3",
+    "layer": "top",
+    "route": [
+      {
+        "x": 7.875,
+        "y": 1.175
+      },
+      {
+        "x": 7.875,
+        "y": 3.425
+      },
+      {
+        "x": 6.125,
+        "y": 3.425
+      },
+      {
+        "x": 6.125,
+        "y": 1.175
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_7",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 8.375,
+      "y": 2
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C1",
+    "ccw_rotation": 270,
+    "pcb_component_id": "pcb_component_3",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_32",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": 5.249929999999836,
+    "y": -12.249932000000058,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_33",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": 5.249929999999836,
+    "y": -12.249932000000058,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_34",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": 5.249929999999836,
+    "y": -7.750067999999942,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_35",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": 5.249929999999836,
+    "y": -7.750067999999942,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_36",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": -1.2499299999999494,
+    "y": -7.750067999999942,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_37",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": -1.2499299999999494,
+    "y": -7.750067999999942,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_38",
+    "layer": "top",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": -1.2499299999999494,
+    "y": -12.249932000000058,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_39",
+    "layer": "bottom",
+    "shape": "circle",
+    "radius": 0.9999979999999999,
+    "x": -1.2499299999999494,
+    "y": -12.249932000000058,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_3",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -0.2743160000001126,
+        "y": -12.999994000000015
+      },
+      {
+        "x": 4.274315999999999,
+        "y": -12.999994000000015
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_4",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": -0.9999940000001288,
+        "y": -8.900002199999903
+      },
+      {
+        "x": -0.9999940000001288,
+        "y": -10.999998000000005
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_5",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": 5.099993799999879,
+        "y": -8.972011199999997
+      },
+      {
+        "x": 5.099993799999879,
+        "y": -11.099997799999983
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_6",
+    "pcb_component_id": "pcb_component_4",
+    "layer": "top",
+    "route": [
+      {
+        "x": 0.000003999999989900971,
+        "y": -7.000005999999985
+      },
+      {
+        "x": 4.274315999999999,
+        "y": -7.000005999999985
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_40",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 2.825,
+    "y": -5,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_24",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_41",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 1.175,
+    "y": -5,
+    "pcb_component_id": "pcb_component_5",
+    "pcb_smtpad_id": "pcb_smtpad_25",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_7",
+    "pcb_component_id": "pcb_component_5",
+    "layer": "top",
+    "route": [
+      {
+        "x": 1.1749999999999998,
+        "y": -5.875
+      },
+      {
+        "x": 3.425,
+        "y": -5.875
+      },
+      {
+        "x": 3.425,
+        "y": -4.125
+      },
+      {
+        "x": 1.1750000000000003,
+        "y": -4.125
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_8",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 1.9999999999999998,
+      "y": -6.375
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "C2",
+    "ccw_rotation": 180,
+    "pcb_component_id": "pcb_component_5",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_42",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 8.175,
+    "y": -3,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_26",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_43",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 9.825,
+    "y": -3,
+    "pcb_component_id": "pcb_component_6",
+    "pcb_smtpad_id": "pcb_smtpad_27",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_8",
+    "pcb_component_id": "pcb_component_6",
+    "layer": "top",
+    "route": [
+      {
+        "x": 9.825,
+        "y": -2.125
+      },
+      {
+        "x": 7.575,
+        "y": -2.125
+      },
+      {
+        "x": 7.575,
+        "y": -3.875
+      },
+      {
+        "x": 9.825,
+        "y": -3.875
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_9",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 9,
+      "y": -1.625
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "R2",
+    "ccw_rotation": 0,
+    "pcb_component_id": "pcb_component_6",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_44",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 9.825,
+    "y": -6,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_28",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_solder_paste",
+    "pcb_solder_paste_id": "pcb_solder_paste_45",
+    "layer": "top",
+    "shape": "rect",
+    "width": 0.5599999999999999,
+    "height": 0.6649999999999999,
+    "x": 8.175,
+    "y": -6,
+    "pcb_component_id": "pcb_component_7",
+    "pcb_smtpad_id": "pcb_smtpad_29",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_9",
+    "pcb_component_id": "pcb_component_7",
+    "layer": "top",
+    "route": [
+      {
+        "x": 8.175,
+        "y": -6.875
+      },
+      {
+        "x": 10.425,
+        "y": -6.875
+      },
+      {
+        "x": 10.425,
+        "y": -5.125
+      },
+      {
+        "x": 8.175,
+        "y": -5.125
+      }
+    ],
+    "stroke_width": 0.1,
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_silkscreen_text",
+    "pcb_silkscreen_text_id": "pcb_silkscreen_text_10",
+    "anchor_alignment": "center",
+    "anchor_position": {
+      "x": 9,
+      "y": -7.375
+    },
+    "font": "tscircuit2024",
+    "font_size": 0.4,
+    "layer": "top",
+    "text": "LED_PWR",
+    "ccw_rotation": 180,
+    "pcb_component_id": "pcb_component_7",
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_0",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": -2.925064000000134,
+    "source_port_id": "source_port_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_1",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": -2.2750780000000077,
+    "source_port_id": "source_port_1"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_2",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": -1.625092000000109,
+    "source_port_id": "source_port_2"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_3",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": -0.9751059999999827,
+    "source_port_id": "source_port_3"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_4",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": -0.3248660000000429,
+    "source_port_id": "source_port_4"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_5",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": 0.3251200000000834,
+    "source_port_id": "source_port_5"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_6",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": 0.9751059999999823,
+    "source_port_id": "source_port_6"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_7",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": 1.6250919999999949,
+    "source_port_id": "source_port_7"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_8",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": 2.2750780000000077,
+    "source_port_id": "source_port_8"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_9",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 2.870961999999963,
+    "y": 2.9250640000000203,
+    "source_port_id": "source_port_9"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_10",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": 2.9250640000000203,
+    "source_port_id": "source_port_10"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_11",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": 2.2750780000000077,
+    "source_port_id": "source_port_11"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_12",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": 1.6250919999999953,
+    "source_port_id": "source_port_12"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_13",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": 0.9751059999999827,
+    "source_port_id": "source_port_13"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_14",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": 0.32512000000008373,
+    "source_port_id": "source_port_14"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_15",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": -0.32486600000004257,
+    "source_port_id": "source_port_15"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_16",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": -0.9751059999999823,
+    "source_port_id": "source_port_16"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_17",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": -1.6250920000001086,
+    "source_port_id": "source_port_17"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_18",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": -2.2750780000000077,
+    "source_port_id": "source_port_18"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_19",
+    "pcb_component_id": "pcb_component_0",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.870961999999963,
+    "y": -2.925064000000134,
+    "source_port_id": "source_port_19"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_20",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": -2.08,
+    "y": 7,
+    "source_port_id": "source_port_20"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_21",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 0.45999999999999996,
+    "y": 7,
+    "source_port_id": "source_port_21"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_22",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 3,
+    "y": 7,
+    "source_port_id": "source_port_22"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_23",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 5.54,
+    "y": 7,
+    "source_port_id": "source_port_23"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_24",
+    "pcb_component_id": "pcb_component_1",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 8.08,
+    "y": 7,
+    "source_port_id": "source_port_24"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_25",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 10,
+    "y": 2.825,
+    "source_port_id": "source_port_25"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_26",
+    "pcb_component_id": "pcb_component_2",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 10,
+    "y": 1.175,
+    "source_port_id": "source_port_26"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_27",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 7,
+    "y": 2.825,
+    "source_port_id": "source_port_27"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_28",
+    "pcb_component_id": "pcb_component_3",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_2",
+    "x": 7,
+    "y": 1.175,
+    "source_port_id": "source_port_28"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_29",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0",
+    "x": -1.2499299999999494,
+    "y": -7.750067999999942,
+    "source_port_id": "source_port_29"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_30",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0",
+    "x": 5.249929999999836,
+    "y": -7.750067999999942,
+    "source_port_id": "source_port_30"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_31",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0",
+    "x": -1.2499299999999494,
+    "y": -12.249932000000058,
+    "source_port_id": "source_port_31"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_32",
+    "pcb_component_id": "pcb_component_4",
+    "layers": [
+      "top",
+      "inner1",
+      "inner2",
+      "bottom"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0",
+    "x": 5.249929999999836,
+    "y": -12.249932000000058,
+    "source_port_id": "source_port_32"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_33",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0",
+    "x": 2.825,
+    "y": -5,
+    "source_port_id": "source_port_33"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_34",
+    "pcb_component_id": "pcb_component_5",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_0",
+    "x": 1.175,
+    "y": -5,
+    "source_port_id": "source_port_34"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_35",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1",
+    "x": 8.175,
+    "y": -3,
+    "source_port_id": "source_port_35"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_36",
+    "pcb_component_id": "pcb_component_6",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1",
+    "x": 9.825,
+    "y": -3,
+    "source_port_id": "source_port_36"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_37",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1",
+    "x": 9.825,
+    "y": -6,
+    "source_port_id": "source_port_37"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_38",
+    "pcb_component_id": "pcb_component_7",
+    "layers": [
+      "top"
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "pcb_group_id": "pcb_group_1",
+    "x": 8.175,
+    "y": -6,
+    "source_port_id": "source_port_38"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_0",
+    "position": {
+      "x": 0,
+      "y": -5.684341886080802e-14,
+      "z": 0
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 90
+    },
+    "pcb_component_id": "pcb_component_0",
+    "source_component_id": "source_component_0",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=f8ba5b4174b9490d8c445fbe2ed40b80&pn=C5187096&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_1",
+    "position": {
+      "x": 3,
+      "y": 7,
+      "z": 0
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_1",
+    "source_component_id": "source_component_1",
+    "footprinter_string": "pinrow5"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_2",
+    "position": {
+      "x": 10,
+      "y": 2,
+      "z": 0
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": -90
+    },
+    "pcb_component_id": "pcb_component_2",
+    "source_component_id": "source_component_2",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_3",
+    "position": {
+      "x": 7,
+      "y": 2,
+      "z": 0
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": -90
+    },
+    "pcb_component_id": "pcb_component_3",
+    "source_component_id": "source_component_3",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_4",
+    "position": {
+      "x": 1.9999999999999432,
+      "y": -10,
+      "z": 3.1
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_4",
+    "source_component_id": "source_component_4",
+    "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=6ef04b62f1e945518af209609f65fa6f&pn=C110153&cachebust_origin=https%3A%2F%2Ftscircuit.com"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_5",
+    "position": {
+      "x": 2,
+      "y": -5,
+      "z": 0
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_5",
+    "source_component_id": "source_component_5",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_6",
+    "position": {
+      "x": 9,
+      "y": -3,
+      "z": 0
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "pcb_component_id": "pcb_component_6",
+    "source_component_id": "source_component_6",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "cad_component",
+    "cad_component_id": "cad_component_7",
+    "position": {
+      "x": 9,
+      "y": -6,
+      "z": 0
+    },
+    "rotation": {
+      "x": 0,
+      "y": 0,
+      "z": 180
+    },
+    "pcb_component_id": "pcb_component_7",
+    "source_component_id": "source_component_7",
+    "footprinter_string": "0603"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_5_0",
+    "connection_name": "source_net_5",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 3,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3,
+        "y": 5.656162522657196,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.7128573701192455,
+        "y": 5.369019892776441,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.647769137500016,
+        "y": 5.15626093749999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 2.647769137500016,
+        "y": 5.15626093749999,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.647769137500016,
+        "y": 5.15626093749999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.6090530826894627,
+        "y": 5.15626093749999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.1307123251264697,
+        "y": 3.416495529684058,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.3053438312499934,
+        "y": 3.3593914062499852,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -1.3053438312499934,
+        "y": 3.3593914062499852,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.3053438312499934,
+        "y": 3.3593914062499852,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.3053438312499934,
+        "y": -0.8243450751833146,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.135036530259003,
+        "y": -1.654037774192324,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.8420162258077477,
+        "y": -1.654037774192324,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.870961999999963,
+        "y": -1.6250920000001086,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_5"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst0_0",
+    "connection_name": "source_net_4",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 5.249929999999836,
+        "y": -7.750067999999942,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.767554164174108,
+        "y": -8.23244383582567,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.9500226070726625,
+        "y": -8.23244383582567,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5007279805728977,
+        "y": -7.783149209325905,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5007279805728977,
+        "y": -7.187670769914578,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5856612096037155,
+        "y": -6.779976355366476,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.5856612096037155,
+        "y": -6.779976355366476,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.5856612096037155,
+        "y": -6.779976355366476,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.6095353850409788,
+        "y": -6.779976355366476,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.1215073970132066,
+        "y": -7.291948367338704,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.272381440396313,
+        "y": -7.43641776525784,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 2.272381440396313,
+        "y": -7.43641776525784,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.272381440396313,
+        "y": -7.43641776525784,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.491952367907222,
+        "y": -7.216846837746931,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.491952367907222,
+        "y": -5.497963184726649,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.491952367907222,
+        "y": -5.333047632092779,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.825,
+        "y": -5,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_4"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst1_0",
+    "connection_name": "source_net_4",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.825,
+        "y": -5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.7345642098639265,
+        "y": -3.9095642098639263,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.7345642098639265,
+        "y": -1.2199473287854437,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.626120671214502,
+        "y": -1.2199473287854437,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": -0.9751059999999827,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_4"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_4_mst2_0",
+    "connection_name": "source_net_4",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": -0.9751059999999827,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.6246485813502682,
+        "y": -0.9751059999999827,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2597594595254573,
+        "y": -0.6102168781751718,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2102735125000128,
+        "y": -0.5937215625000236,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 1.2102735125000128,
+        "y": -0.5937215625000236,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2102735125000128,
+        "y": -0.5937215625000236,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2102735125000128,
+        "y": 2.155287913344721,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2102735125000128,
+        "y": 2.155287913344721,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2102735125000128,
+        "y": 2.2983827306547453,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 1.2102735125000128,
+        "y": 2.2983827306547453,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2102735125000128,
+        "y": 2.2983827306547453,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.2102735125000128,
+        "y": 6.249726487499987,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.45999999999999996,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_4"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst0_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 8.08,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.08,
+        "y": 5.6118456656213525,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.335806598129452,
+        "y": 5.356039067491901,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.39775163750003,
+        "y": 5.15626093749999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 8.39775163750003,
+        "y": 5.15626093749999,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.39775163750003,
+        "y": 5.15626093749999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.39775163750003,
+        "y": 2.5519658163783268,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.500000000000002,
+        "y": 2.449717453878354,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.500000000000002,
+        "y": 2.3000000000000003,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 8.500000000000002,
+        "y": 2.3000000000000003,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.500000000000002,
+        "y": 2.3000000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.875,
+        "y": 2.3000000000000003,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10,
+        "y": 1.175,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_3"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_3_mst1_0",
+    "connection_name": "source_net_3",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 10,
+        "y": 1.175,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.639880079816423,
+        "y": -0.18511992018357581,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.56347267199526,
+        "y": -0.18511992018357581,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.100172583104673,
+        "y": -0.18511992018357581,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.6602005032881393,
+        "y": -1.625092000000109,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": -1.625092000000109,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": -1.625092000000109,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_3"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_2_0",
+    "connection_name": "source_net_2",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 5.54,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.54,
+        "y": 5.2674586240789045,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.527705316883331,
+        "y": 5.255163940962236,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.522760387500023,
+        "y": 5.15626093749999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 5.522760387500023,
+        "y": 5.15626093749999,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.522760387500023,
+        "y": 5.15626093749999,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.522760387500023,
+        "y": 4.555286661695548,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.279163765133177,
+        "y": 1.798883284062394,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.279163765133177,
+        "y": 1.186507792334834,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.936482836648839,
+        "y": -0.4708112791808281,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.835247262500033,
+        "y": -0.5937215625000236,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 9.835247262500033,
+        "y": -0.5937215625000236,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.835247262500033,
+        "y": -0.5937215625000236,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.354955690248066,
+        "y": -0.5937215625000236,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.5795396955993612,
+        "y": -2.3691375571487288,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.965021557148684,
+        "y": -2.3691375571487288,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": -2.2750780000000077,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_2"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst0_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 1.175,
+        "y": -5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.175,
+        "y": -5.325137999999993,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -1.2499299999999494,
+        "y": -7.750067999999942,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst1_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": 0.9751059999999823,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.800105999999982,
+        "y": 0.9751059999999823,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7,
+        "y": 1.175,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst2_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 1.175,
+        "y": -5,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.7331974588471755,
+        "y": -4.558197458847175,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.7331974588471755,
+        "y": 0.8500000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.745855999999981,
+        "y": 0.8500000000000001,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": 0.9751059999999823,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst3_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 8.175,
+        "y": -6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 3.647019636769924,
+        "y": -6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.7829875252517997,
+        "y": -6.864032111518124,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.7829875252517997,
+        "y": -7.626301611976199,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.658137666916659,
+        "y": -7.751151470311339,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.283931765962226,
+        "y": -7.948787592608476,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.283931765962226,
+        "y": -7.948787592608476,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.9182485745338669,
+        "y": -7.806885258185425,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.7848151133291315,
+        "y": -7.5943270009288995,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.751954892068791,
+        "y": -7.293430806775951,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 1.751954892068791,
+        "y": -7.293430806775951,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.1060877579312374,
+        "y": -6.922963313848365,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.1060877579312374,
+        "y": -6.922963313848365,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.0622169847978147,
+        "y": -6.8323575824689975,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.0622169847978147,
+        "y": -6.6330776715685005,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.073227536670897,
+        "y": -6.6220671196954175,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_1_mst4_0",
+    "connection_name": "source_net_1",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": 0.9751059999999823,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.164215354469814,
+        "y": 0.9751059999999823,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.31034848487276,
+        "y": 1.1212391304029279,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.44463866875002,
+        "y": 1.2031479687499806,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 4.44463866875002,
+        "y": 1.2031479687499806,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 4.44463866875002,
+        "y": 1.2031479687499806,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 2.8383895350369897,
+        "y": 2.809397102463011,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.40385019999461563,
+        "y": 2.809397102463011,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 0.4013925145614238,
+        "y": 2.809397102463011,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.12673490040160415,
+        "y": 2.281269687499983,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.2272221124999907,
+        "y": 2.281269687499983,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": -0.2272221124999907,
+        "y": 2.281269687499983,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.2272221124999907,
+        "y": 2.281269687499983,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -0.2272221124999907,
+        "y": 5.147222112499991,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": -2.08,
+        "y": 7,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_1"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst0_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7,
+        "y": 2.825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10,
+        "y": 2.825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 10,
+        "y": 2.825,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst1_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 2.870961999999963,
+        "y": 2.2750780000000077,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.4500780000000075,
+        "y": 2.2750780000000077,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7,
+        "y": 2.825,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_net_0_mst2_0",
+    "connection_name": "source_net_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 7,
+        "y": 2.825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 6.104167930578225,
+        "y": 2.825,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.677016375677224,
+        "y": 2.397848445098999,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.522760387500023,
+        "y": 2.281269687499983,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "via",
+        "x": 5.522760387500023,
+        "y": 2.281269687499983,
+        "from_layer": "top",
+        "to_layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.522760387500023,
+        "y": 2.281269687499983,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 5.522760387500023,
+        "y": -0.48122747780202424,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.145939846124785,
+        "y": -2.104406936426786,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.05,
+        "y": -2.3000000000000007,
+        "width": 0.15,
+        "layer": "bottom"
+      },
+      {
+        "route_type": "via",
+        "x": 7.05,
+        "y": -2.3000000000000007,
+        "from_layer": "bottom",
+        "to_layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.05,
+        "y": -2.3000000000000007,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 7.475000000000001,
+        "y": -2.3000000000000007,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 8.175,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_net_0"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_21_0",
+    "connection_name": "source_trace_21",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 9.825,
+        "y": -6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.825,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.825,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_trace_21"
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "source_trace_20_0",
+    "connection_name": "source_trace_20",
+    "route": [
+      {
+        "route_type": "wire",
+        "x": 9.825,
+        "y": -6,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.825,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top"
+      },
+      {
+        "route_type": "wire",
+        "x": 9.825,
+        "y": -3,
+        "width": 0.15,
+        "layer": "top"
+      }
+    ],
+    "subcircuit_id": "subcircuit_source_group_2",
+    "source_trace_id": "source_trace_20"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_0",
+    "pcb_trace_id": "source_net_5_0",
+    "x": 2.647769137500016,
+    "y": 5.15626093749999,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_1",
+    "pcb_trace_id": "source_net_5_0",
+    "x": -1.3053438312499934,
+    "y": 3.3593914062499852,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_2",
+    "pcb_trace_id": "source_net_4_mst0_0",
+    "x": 1.5856612096037155,
+    "y": -6.779976355366476,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_3",
+    "pcb_trace_id": "source_net_4_mst0_0",
+    "x": 2.272381440396313,
+    "y": -7.43641776525784,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_4",
+    "pcb_trace_id": "source_net_4_mst2_0",
+    "x": 1.2102735125000128,
+    "y": -0.5937215625000236,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_5",
+    "pcb_trace_id": "source_net_4_mst2_0",
+    "x": 1.2102735125000128,
+    "y": 2.2983827306547453,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_6",
+    "pcb_trace_id": "source_net_3_mst0_0",
+    "x": 8.39775163750003,
+    "y": 5.15626093749999,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_7",
+    "pcb_trace_id": "source_net_3_mst0_0",
+    "x": 8.500000000000002,
+    "y": 2.3000000000000003,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_8",
+    "pcb_trace_id": "source_net_2_0",
+    "x": 5.522760387500023,
+    "y": 5.15626093749999,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_9",
+    "pcb_trace_id": "source_net_2_0",
+    "x": 9.835247262500033,
+    "y": -0.5937215625000236,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_10",
+    "pcb_trace_id": "source_net_1_mst4_0",
+    "x": 4.44463866875002,
+    "y": 1.2031479687499806,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_11",
+    "pcb_trace_id": "source_net_1_mst4_0",
+    "x": -0.2272221124999907,
+    "y": 2.281269687499983,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_12",
+    "pcb_trace_id": "source_net_0_mst2_0",
+    "x": 5.522760387500023,
+    "y": 2.281269687499983,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "top",
+      "bottom"
+    ],
+    "from_layer": "top",
+    "to_layer": "bottom"
+  },
+  {
+    "type": "pcb_via",
+    "pcb_via_id": "pcb_via_13",
+    "pcb_trace_id": "source_net_0_mst2_0",
+    "x": 7.05,
+    "y": -2.3000000000000007,
+    "hole_diameter": 0.3,
+    "outer_diameter": 0.6,
+    "layers": [
+      "bottom",
+      "top"
+    ],
+    "from_layer": "bottom",
+    "to_layer": "top"
+  }
+]

--- a/tests/lib/repro-trace-disconnection.test.ts
+++ b/tests/lib/repro-trace-disconnection.test.ts
@@ -5,32 +5,37 @@ import reproTraceDisconnection from "../assets/repro-trace-disconnection.json"
 
 test("repro-trace-disconnection should detect disconnected traces", async () => {
   const errors = await runAllChecks(reproTraceDisconnection as any)
-  
+
   console.log("Total errors found:", errors.length)
-  
+
   // Check if there's a trace disconnection error
   const traceErrors = errors.filter((e: any) => e.type === "pcb_trace_error")
   console.log("Trace errors:", traceErrors.length)
   console.log("Trace error details:", JSON.stringify(traceErrors, null, 2))
-  
+
   // There should be at least one error for the disconnected trace
   expect(errors.length).toBeGreaterThan(0)
   expect(traceErrors.length).toBeGreaterThan(0)
 })
 
 test("repro-trace-disconnection - specific check for source_net_1_mst3_0 disconnection", () => {
-  const contiguityErrors = checkTracesAreContiguous(reproTraceDisconnection as any)
-  
+  const contiguityErrors = checkTracesAreContiguous(
+    reproTraceDisconnection as any,
+  )
+
   console.log("Contiguity errors:", contiguityErrors.length)
-  console.log("Contiguity error details:", JSON.stringify(contiguityErrors, null, 2))
-  
+  console.log(
+    "Contiguity error details:",
+    JSON.stringify(contiguityErrors, null, 2),
+  )
+
   // Find the specific trace error for source_net_1_mst3_0
   const disconnectedTraceError = contiguityErrors.find(
-    (e) => e.pcb_trace_id === "source_net_1_mst3_0"
+    (e) => e.pcb_trace_id === "source_net_1_mst3_0",
   )
-  
+
   console.log("Disconnected trace error found:", !!disconnectedTraceError)
-  
+
   // This trace should have an error because it doesn't connect to LED_PWR cathode properly
   expect(disconnectedTraceError).toBeDefined()
 })

--- a/tests/lib/repro-trace-disconnection.test.ts
+++ b/tests/lib/repro-trace-disconnection.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test"
+import { runAllChecks } from "../../lib/run-all-checks"
+import { checkTracesAreContiguous } from "../../lib/check-traces-are-contiguous/check-traces-are-contiguous"
+import reproTraceDisconnection from "../assets/repro-trace-disconnection.json"
+
+test("repro-trace-disconnection should detect disconnected traces", async () => {
+  const errors = await runAllChecks(reproTraceDisconnection as any)
+  
+  console.log("Total errors found:", errors.length)
+  
+  // Check if there's a trace disconnection error
+  const traceErrors = errors.filter((e: any) => e.type === "pcb_trace_error")
+  console.log("Trace errors:", traceErrors.length)
+  console.log("Trace error details:", JSON.stringify(traceErrors, null, 2))
+  
+  // There should be at least one error for the disconnected trace
+  expect(errors.length).toBeGreaterThan(0)
+  expect(traceErrors.length).toBeGreaterThan(0)
+})
+
+test("repro-trace-disconnection - specific check for source_net_1_mst3_0 disconnection", () => {
+  const contiguityErrors = checkTracesAreContiguous(reproTraceDisconnection as any)
+  
+  console.log("Contiguity errors:", contiguityErrors.length)
+  console.log("Contiguity error details:", JSON.stringify(contiguityErrors, null, 2))
+  
+  // Find the specific trace error for source_net_1_mst3_0
+  const disconnectedTraceError = contiguityErrors.find(
+    (e) => e.pcb_trace_id === "source_net_1_mst3_0"
+  )
+  
+  console.log("Disconnected trace error found:", !!disconnectedTraceError)
+  
+  // This trace should have an error because it doesn't connect to LED_PWR cathode properly
+  expect(disconnectedTraceError).toBeDefined()
+})


### PR DESCRIPTION
/claim https://github.com/tscircuit/core/issues/1425
/closes https://github.com/tscircuit/core/issues/1425

The function had `if (!sourceTrace) continue` which skipped ALL net-level traces (traces with IDs like `source_net_1` instead of `source_trace_22`). This meant disconnected endpoints in net-level traces were never detected.

Solution (3 changes):
1. Removed the skip: Deleted `if (!sourceTrace) continue` so net-level traces are now checked
2. Handle undefined sourceTrace: Changed to `const expectedPorts = sourceTrace ? pcbPorts.filter(...) : []` and added `?.` operators
3. Added floating endpoint check: For net-level traces (with no `expectedPorts`, check if both endpoints connect to ANY pad. If not, report the disconnected endpoint with coordinates.