### PR TITLE
fix: skip courtyard overlap check for different layers

### DIFF
--- a/lib/check-courtyard-overlap/checkCourtyardOverlap.ts
+++ b/lib/check-courtyard-overlap/checkCourtyardOverlap.ts
@@ -118,6 +118,10 @@ export function checkCourtyardOverlap(
       let overlapping = false
       outer: for (const a of byComponent.get(idA)!) {
         for (const b of byComponent.get(idB)!) {
+          // Skip overlap check if courtyards are on different layers
+          if ("layer" in a && "layer" in b && a.layer !== b.layer) {
+            continue
+          }
           const polyA = getCourtyardPolygon(a)
           const polyB = getCourtyardPolygon(b)
           if (polygonsOverlap(polyA, polyB)) {

--- a/tests/lib/check-pcb-component-overlap/courtyard-different-layers-no-overlap.test.tsx
+++ b/tests/lib/check-pcb-component-overlap/courtyard-different-layers-no-overlap.test.tsx
@@ -1,0 +1,126 @@
+import { expect, test } from "bun:test"
+import { checkCourtyardOverlap } from "lib/check-courtyard-overlap/checkCourtyardOverlap"
+
+/**
+ * Two components at the same position but on different layers (top vs bottom)
+ * should NOT produce a courtyard overlap error.
+ *
+ * Regression test for: https://github.com/tscircuit/core/issues/2084
+ */
+
+test("courtyards on different layers should not produce overlap error", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_component",
+      pcb_component_id: "comp1",
+      source_component_id: "src1",
+      center: { x: 0, y: 0 },
+      layer: "top",
+      rotation: 0,
+      width: 4,
+      height: 2,
+    },
+    {
+      type: "source_component",
+      source_component_id: "src1",
+      name: "R1",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "cy1",
+      pcb_component_id: "comp1",
+      center: { x: 0, y: 0 },
+      width: 4,
+      height: 2,
+      layer: "top",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "comp2",
+      source_component_id: "src2",
+      center: { x: 0, y: 0 },
+      layer: "bottom",
+      rotation: 0,
+      width: 4,
+      height: 2,
+    },
+    {
+      type: "source_component",
+      source_component_id: "src2",
+      name: "R2",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "cy2",
+      pcb_component_id: "comp2",
+      center: { x: 0, y: 0 },
+      width: 4,
+      height: 2,
+      layer: "bottom",
+    },
+  ]
+
+  const errors = checkCourtyardOverlap(circuitJson)
+  expect(errors).toHaveLength(0)
+})
+
+test("courtyards on same layer should still produce overlap error", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_component",
+      pcb_component_id: "comp1",
+      source_component_id: "src1",
+      center: { x: 0, y: 0 },
+      layer: "top",
+      rotation: 0,
+      width: 4,
+      height: 2,
+    },
+    {
+      type: "source_component",
+      source_component_id: "src1",
+      name: "R1",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "cy1",
+      pcb_component_id: "comp1",
+      center: { x: 0, y: 0 },
+      width: 4,
+      height: 2,
+      layer: "top",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "comp2",
+      source_component_id: "src2",
+      center: { x: 1, y: 0 },
+      layer: "top",
+      rotation: 0,
+      width: 4,
+      height: 2,
+    },
+    {
+      type: "source_component",
+      source_component_id: "src2",
+      name: "R2",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "pcb_courtyard_rect",
+      pcb_courtyard_rect_id: "cy2",
+      pcb_component_id: "comp2",
+      center: { x: 1, y: 0 },
+      width: 4,
+      height: 2,
+      layer: "top",
+    },
+  ]
+
+  const errors = checkCourtyardOverlap(circuitJson)
+  expect(errors).toHaveLength(1)
+  expect(errors[0].type).toBe("pcb_courtyard_overlap_error")
+})


### PR DESCRIPTION
## Summary

Fixes tscircuit/core#2084

The courtyard overlap checker was reporting false positives when two components occupy the same XY position but on different PCB layers (top vs bottom). Components on different layers don't physically interfere, so the overlap check should be skipped.

## Changes

- **`checkCourtyardOverlap.ts`**: Added layer comparison before polygon overlap check. If two courtyard elements have different `layer` values, they are skipped.
- **New test**: `courtyard-different-layers-no-overlap.test.tsx` - verifies no error for different-layer courtyards, and confirms same-layer overlap still triggers an error.

## Test plan

- [x] New test for different-layer courtyards passes
- [x] All 17 existing courtyard overlap tests still pass