### PR TITLE
Use pcb_board DRC values and remove JLC specs dependency import

### DIFF
--- a/lib/check-different-net-via-spacing.ts
+++ b/lib/check-different-net-via-spacing.ts
@@ -8,7 +8,11 @@ import {
   getFullConnectivityMapFromCircuitJson,
   type ConnectivityMap,
 } from "circuit-json-to-connectivity-map"
-import { DEFAULT_DIFFERENT_NET_VIA_MARGIN, EPSILON } from "lib/drc-defaults"
+import {
+  DEFAULT_DIFFERENT_NET_VIA_MARGIN,
+  EPSILON,
+  getBoardDrcValue,
+} from "lib/drc-defaults"
 import { viasAreAtSameLocation } from "lib/util/viasAreAtSameLocation"
 import { distance } from "lib/util/distance"
 
@@ -16,9 +20,14 @@ export function checkDifferentNetViaSpacing(
   circuitJson: AnyCircuitElement[],
   {
     connMap,
-    minClearance = DEFAULT_DIFFERENT_NET_VIA_MARGIN,
+    minClearance,
   }: { connMap?: ConnectivityMap; minClearance?: number } = {},
 ): PcbViaClearanceError[] {
+  minClearance ??= getBoardDrcValue(
+    circuitJson,
+    "min_via_to_via_clearance",
+    DEFAULT_DIFFERENT_NET_VIA_MARGIN,
+  )
   const vias = circuitJson.filter((el) => el.type === "pcb_via") as PcbVia[]
   if (vias.length < 2) return []
   connMap ??= getFullConnectivityMapFromCircuitJson(circuitJson)

--- a/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
+++ b/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_TRACE_MARGIN,
   DEFAULT_TRACE_THICKNESS,
   EPSILON,
+  getBoardDrcValue,
 } from "lib/drc-defaults"
 import { getPcbPortIdsConnectedToTraces } from "./getPcbPortIdsConnectedToTraces"
 import { segmentToSegmentMinDistance } from "@tscircuit/math-utils"
@@ -38,12 +39,18 @@ export function checkEachPcbTraceNonOverlapping(
   circuitJson: AnyCircuitElement[],
   {
     connMap,
-    minClearance = DEFAULT_TRACE_MARGIN,
+    minClearance,
   }: {
     connMap?: ConnectivityMap
     minClearance?: number
   } = {},
 ): PcbTraceError[] {
+  minClearance ??= DEFAULT_TRACE_MARGIN
+  const defaultTraceThickness = getBoardDrcValue(
+    circuitJson,
+    "min_trace_width",
+    DEFAULT_TRACE_THICKNESS,
+  )
   const errors: PcbTraceError[] = []
   addStartAndEndPortIdsIfMissing(circuitJson)
   connMap ??= getFullConnectivityMapFromCircuitJson(circuitJson)
@@ -66,7 +73,7 @@ export function checkEachPcbTraceNonOverlapping(
             ? p1.width
             : "width" in p2
               ? p2.width
-              : DEFAULT_TRACE_THICKNESS,
+              : defaultTraceThickness,
         layer: p1.layer,
         x1: p1.x,
         y1: p1.y,

--- a/lib/check-pad-clearance/common.ts
+++ b/lib/check-pad-clearance/common.ts
@@ -14,7 +14,7 @@ import type {
 } from "circuit-json"
 import type { PcbTraceSegment } from "lib/check-each-pcb-trace-non-overlapping/getCollidableBounds"
 import type { Bounds } from "lib/data-structures/SpatialIndex"
-import { DEFAULT_TRACE_THICKNESS } from "lib/drc-defaults"
+import { DEFAULT_TRACE_THICKNESS, getBoardDrcValue } from "lib/drc-defaults"
 
 export type PadElement = PcbSmtPad | PcbPlatedHole
 
@@ -101,6 +101,11 @@ export const getPads = (circuitJson: AnyCircuitElement[]) =>
 export const getTraceSegments = (
   circuitJson: AnyCircuitElement[],
 ): PcbTraceSegment[] => {
+  const defaultTraceThickness = getBoardDrcValue(
+    circuitJson,
+    "min_trace_width",
+    DEFAULT_TRACE_THICKNESS,
+  )
   const pcbTraces = cju(circuitJson).pcb_trace.list()
 
   return pcbTraces.flatMap((pcbTrace) => {
@@ -122,7 +127,7 @@ export const getTraceSegments = (
             ? p1.width
             : "width" in p2
               ? p2.width
-              : DEFAULT_TRACE_THICKNESS!,
+              : defaultTraceThickness,
         layer: p1.layer,
         x1: p1.x,
         y1: p1.y,

--- a/lib/check-pad-pad-clearance.ts
+++ b/lib/check-pad-pad-clearance.ts
@@ -8,7 +8,11 @@ import {
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
 import { SpatialObjectIndex } from "lib/data-structures/SpatialIndex"
-import { DEFAULT_PAD_PAD_CLEARANCE, EPSILON } from "lib/drc-defaults"
+import {
+  DEFAULT_PAD_PAD_CLEARANCE,
+  EPSILON,
+  getBoardDrcValue,
+} from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import {
   type PadElement,
@@ -23,9 +27,14 @@ export function checkPadPadClearance(
   circuitJson: AnyCircuitElement[],
   {
     connMap,
-    minClearance = DEFAULT_PAD_PAD_CLEARANCE,
+    minClearance,
   }: { connMap?: ConnectivityMap; minClearance?: number } = {},
 ): PcbPadPadClearanceError[] {
+  minClearance ??= getBoardDrcValue(
+    circuitJson,
+    "min_pad_to_pad_clearance",
+    DEFAULT_PAD_PAD_CLEARANCE,
+  )
   const pads = getPads(circuitJson)
   if (pads.length < 2) return []
 

--- a/lib/check-pad-trace-clearance.ts
+++ b/lib/check-pad-trace-clearance.ts
@@ -13,7 +13,11 @@ import {
 } from "circuit-json-to-connectivity-map"
 import { getCollidableBounds } from "lib/check-each-pcb-trace-non-overlapping/getCollidableBounds"
 import { SpatialObjectIndex } from "lib/data-structures/SpatialIndex"
-import { DEFAULT_PAD_TRACE_CLEARANCE, EPSILON } from "lib/drc-defaults"
+import {
+  DEFAULT_PAD_TRACE_CLEARANCE,
+  EPSILON,
+  getBoardDrcValue,
+} from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import {
   type PadElement,
@@ -30,9 +34,14 @@ export function checkPadTraceClearance(
   circuitJson: AnyCircuitElement[],
   {
     connMap,
-    minClearance = DEFAULT_PAD_TRACE_CLEARANCE,
+    minClearance,
   }: { connMap?: ConnectivityMap; minClearance?: number } = {},
 ): PcbPadTraceClearanceError[] {
+  minClearance ??= getBoardDrcValue(
+    circuitJson,
+    "min_trace_to_pad_clearance",
+    DEFAULT_PAD_TRACE_CLEARANCE,
+  )
   const pads = getPads(circuitJson)
   const segments = getTraceSegments(circuitJson)
   if (pads.length === 0 || segments.length === 0) return []

--- a/lib/check-pcb-components-out-of-board/checkViasOffBoard.ts
+++ b/lib/check-pcb-components-out-of-board/checkViasOffBoard.ts
@@ -5,7 +5,7 @@ import type {
   PcbPlacementError,
 } from "circuit-json"
 import { getReadableNameForElement } from "@tscircuit/circuit-json-util"
-import { DEFAULT_VIA_BOARD_MARGIN } from "lib/drc-defaults"
+import { DEFAULT_VIA_BOARD_MARGIN, getBoardDrcValue } from "lib/drc-defaults"
 
 export function checkViasOffBoard(
   circuitJson: AnyCircuitElement[],
@@ -24,6 +24,11 @@ export function checkViasOffBoard(
   const boardMaxX = board.center.x + board.width / 2
   const boardMinY = board.center.y - board.height / 2
   const boardMaxY = board.center.y + board.height / 2
+  const viaBoardMargin = getBoardDrcValue(
+    circuitJson,
+    "min_board_edge_clearance",
+    DEFAULT_VIA_BOARD_MARGIN,
+  )
 
   const errors: PcbPlacementError[] = []
 
@@ -35,10 +40,10 @@ export function checkViasOffBoard(
     const viaMaxY = via.y + viaRadius
 
     if (
-      viaMinX < boardMinX + DEFAULT_VIA_BOARD_MARGIN ||
-      viaMaxX > boardMaxX - DEFAULT_VIA_BOARD_MARGIN ||
-      viaMinY < boardMinY + DEFAULT_VIA_BOARD_MARGIN ||
-      viaMaxY > boardMaxY - DEFAULT_VIA_BOARD_MARGIN
+      viaMinX < boardMinX + viaBoardMargin ||
+      viaMaxX > boardMaxX - viaBoardMargin ||
+      viaMinY < boardMinY + viaBoardMargin ||
+      viaMaxY > boardMaxY - viaBoardMargin
     ) {
       const viaName = getReadableNameForElement(circuitJson, via.pcb_via_id)
       errors.push({

--- a/lib/check-same-net-via-spacing.ts
+++ b/lib/check-same-net-via-spacing.ts
@@ -8,7 +8,11 @@ import {
   getFullConnectivityMapFromCircuitJson,
   type ConnectivityMap,
 } from "circuit-json-to-connectivity-map"
-import { DEFAULT_SAME_NET_VIA_MARGIN, EPSILON } from "lib/drc-defaults"
+import {
+  DEFAULT_SAME_NET_VIA_MARGIN,
+  EPSILON,
+  getBoardDrcValue,
+} from "lib/drc-defaults"
 import { distance } from "lib/util/distance"
 import { viasAreAtSameLocation } from "lib/util/viasAreAtSameLocation"
 
@@ -16,9 +20,14 @@ export function checkSameNetViaSpacing(
   circuitJson: AnyCircuitElement[],
   {
     connMap,
-    minClearance = DEFAULT_SAME_NET_VIA_MARGIN,
+    minClearance,
   }: { connMap?: ConnectivityMap; minClearance?: number } = {},
 ): PcbViaClearanceError[] {
+  minClearance ??= getBoardDrcValue(
+    circuitJson,
+    "min_via_to_via_clearance",
+    DEFAULT_SAME_NET_VIA_MARGIN,
+  )
   const vias = circuitJson.filter((el) => el.type === "pcb_via") as PcbVia[]
   if (vias.length < 2) return []
   connMap ??= getFullConnectivityMapFromCircuitJson(circuitJson)

--- a/lib/check-via-trace-clearance.ts
+++ b/lib/check-via-trace-clearance.ts
@@ -9,7 +9,11 @@ import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
-import { DEFAULT_PAD_TRACE_CLEARANCE, EPSILON } from "lib/drc-defaults"
+import {
+  DEFAULT_PAD_TRACE_CLEARANCE,
+  EPSILON,
+  getBoardDrcValue,
+} from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import { formatMm, getTraceSegments } from "./check-pad-clearance/common"
 
@@ -43,9 +47,14 @@ export function checkViaTraceClearance(
   circuitJson: AnyCircuitElement[],
   {
     connMap,
-    minClearance = DEFAULT_PAD_TRACE_CLEARANCE,
+    minClearance,
   }: { connMap?: ConnectivityMap; minClearance?: number } = {},
 ): PcbViaTraceClearanceError[] {
+  minClearance ??= getBoardDrcValue(
+    circuitJson,
+    "min_trace_to_pad_clearance",
+    DEFAULT_PAD_TRACE_CLEARANCE,
+  )
   const vias = circuitJson.filter((el) => el.type === "pcb_via") as PcbVia[]
   const segments = getTraceSegments(circuitJson)
   if (vias.length === 0 || segments.length === 0) return []

--- a/lib/drc-defaults.ts
+++ b/lib/drc-defaults.ts
@@ -1,18 +1,33 @@
-import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
+import type {
+  AnyCircuitElement,
+  ManufacturingDrcProperties,
+} from "circuit-json"
 
 export const DEFAULT_TRACE_MARGIN = 0.1
-export const DEFAULT_TRACE_THICKNESS = jlcMinTolerances.min_trace_width
-export const DEFAULT_VIA_DIAMETER = jlcMinTolerances.min_via_pad_diameter
+export const DEFAULT_TRACE_THICKNESS = 0.1
+export const DEFAULT_VIA_DIAMETER = 0.3
 export const DEFAULT_VIA_BOARD_MARGIN = 0.3
 
-export const DEFAULT_SAME_NET_VIA_MARGIN =
-  jlcMinTolerances.min_via_to_via_clearance
-export const DEFAULT_DIFFERENT_NET_VIA_MARGIN =
-  jlcMinTolerances.min_via_to_via_clearance
+export const DEFAULT_SAME_NET_VIA_MARGIN = 0.1
+export const DEFAULT_DIFFERENT_NET_VIA_MARGIN = 0.1
 
-export const DEFAULT_PAD_PAD_CLEARANCE =
-  jlcMinTolerances.min_pad_to_pad_clearance
-export const DEFAULT_PAD_TRACE_CLEARANCE =
-  jlcMinTolerances.min_trace_to_pad_clearance
+export const DEFAULT_PAD_PAD_CLEARANCE = 0.1
+export const DEFAULT_PAD_TRACE_CLEARANCE = 0.1
 
 export const EPSILON = 0.005
+
+export type BoardDrcPropertyKey = keyof ManufacturingDrcProperties
+
+export const getBoardDrcValue = (
+  circuitJson: AnyCircuitElement[],
+  key: BoardDrcPropertyKey,
+  fallback: number,
+): number => {
+  const board = circuitJson.find(
+    (element): element is AnyCircuitElement & ManufacturingDrcProperties =>
+      element.type === "pcb_board",
+  )
+
+  const value = board?.[key]
+  return typeof value === "number" ? value : fallback
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
     "@tscircuit/circuit-json-util": "^0.0.93",
-    "@tscircuit/jlcpcb-manufacturing-specs": "git+https://github.com/tscircuit/jlcpcb-manufacturing-specs#5644e294acfdd545ceb468c3b95c9ed82cb9a00b",
     "@tscircuit/log-soup": "^1.0.2",
     "@types/bun": "^1.2.8",
     "@types/debug": "^4.1.12",


### PR DESCRIPTION
### Motivation
- Remove the hard dependency on `@tscircuit/jlcpcb-manufacturing-specs` and instead use DRC values embedded in the `pcb_board` element of the circuit JSON. 
- Allow board-level manufacturing DRC properties to override library defaults so checks reflect per-board constraints.

### Description
- Removed `@tscircuit/jlcpcb-manufacturing-specs` from `devDependencies` and replaced dependency-backed defaults with local numeric fallbacks in `lib/drc-defaults.ts`. 
- Added `getBoardDrcValue(circuitJson, key, fallback)` to read manufacturing DRC properties from the `pcb_board` element and return a typed numeric fallback when unset. 
- Updated clearance/thickness fallbacks so checks read from board DRC properties when `minClearance` or trace widths are not explicitly provided: pad-pad uses `min_pad_to_pad_clearance`, pad-trace and via-trace use `min_trace_to_pad_clearance`, via spacing uses `min_via_to_via_clearance`, and trace thickness falls back to `min_trace_width`. 
- Updated via off-board checks to use `min_board_edge_clearance` (with fallback) for the board-edge margin.

### Testing
- `npm run build` completed successfully. 
- Ran `npx biome format --write` on all touched files (succeeded) to apply formatter fixes. 
- `npm run format:check` initially reported repository-level warnings due to large test fixtures, and formatter suggestions were applied to the modified files; formatting of touched files is now applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea6b4c8988832798e9dffd04235f77)