### PR TITLE
Adds comprehensive support for Rotated-Pill Pad Geometry across DRC, Connectivity, and Trace Validation

### DIFF
--- a/lib/add-start-and-end-port-ids-if-missing.ts
+++ b/lib/add-start-and-end-port-ids-if-missing.ts
@@ -4,6 +4,7 @@ import type {
   AnyCircuitElement,
   PcbSmtPad,
 } from "circuit-json"
+import { isPointInPad } from "lib/check-traces-are-contiguous/is-point-in-pad"
 
 function distance(x1: number, y1: number, x2: number, y2: number): number {
   return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
@@ -46,6 +47,8 @@ export const addStartAndEndPortIdsIfMissing = (
           // biome-ignore lint/style/noUselessElse: <explanation>
         } else if (pad.shape === "circle") {
           return distance(point.x, point.y, pad.x, pad.y) < pad.radius
+        } else if (pad.shape === "pill" || pad.shape === "rotated_pill") {
+          return isPointInPad(point, pad)
         }
       })
       if (smtPad) return smtPad.pcb_port_id ?? null

--- a/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
+++ b/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
@@ -34,6 +34,7 @@ import { getPcbPortIdsConnectedToTraces } from "./getPcbPortIdsConnectedToTraces
 import { getRadiusOfCircuitJsonElement } from "./getRadiusOfCircuitJsonElement"
 import {
   getPolygonPointsForPad,
+  getSegmentToPillClearance,
   getSegmentToPolygonClearance,
 } from "./segment-to-polygon-clearance"
 
@@ -237,6 +238,42 @@ export function checkEachPcbTraceNonOverlapping(
             "pcb_port_id" in obj ? obj.pcb_port_id : undefined,
           ].filter(Boolean) as string[],
         })
+      }
+
+      if (obj.type === "pcb_smtpad" && obj.shape === "rotated_pill") {
+        const { distance, center, radius } = getSegmentToPillClearance(
+          segmentA,
+          obj,
+        )
+        const gap = distance - segmentA.thickness / 2 - radius
+        if (gap > minClearance - EPSILON) continue
+
+        const pcb_trace_error_id = `overlap_${segmentA.pcb_trace_id}_${primaryObjId}`
+        if (errorIds.has(pcb_trace_error_id)) continue
+        errorIds.add(pcb_trace_error_id)
+        errors.push({
+          type: "pcb_trace_error",
+          error_type: "pcb_trace_error",
+          message: constructErrorMessage(
+            getReadableName(segmentA.pcb_trace_id),
+            `${obj.type} "${getReadableName(getPrimaryId(obj))}"`,
+            gap,
+          ),
+          pcb_trace_id: segmentA.pcb_trace_id,
+          center,
+          source_trace_id: "",
+          pcb_trace_error_id,
+          pcb_component_ids: [
+            "pcb_component_id" in obj
+              ? (obj.pcb_component_id as string)
+              : undefined,
+          ].filter(Boolean) as string[],
+          pcb_port_ids: [
+            ...getPcbPortIdsConnectedToTraces([segmentA._pcbTrace]),
+            "pcb_port_id" in obj ? obj.pcb_port_id : undefined,
+          ].filter(Boolean) as string[],
+        })
+        continue
       }
 
       const isPolygon =

--- a/lib/check-each-pcb-trace-non-overlapping/getCollidableBounds.ts
+++ b/lib/check-each-pcb-trace-non-overlapping/getCollidableBounds.ts
@@ -9,7 +9,10 @@ import type {
   PcbTraceError,
   PcbVia,
 } from "circuit-json"
-import { getPolygonPointsForPad } from "./segment-to-polygon-clearance"
+import {
+  getPillCenterLineForPad,
+  getPolygonPointsForPad,
+} from "./segment-to-polygon-clearance"
 
 interface Bounds {
   minX: number
@@ -67,6 +70,19 @@ export const getCollidableBounds = (collidable: Collidable): Bounds => {
         minY: Math.min(...polygonPoints.map((point) => point.y)),
         maxX: Math.max(...polygonPoints.map((point) => point.x)),
         maxY: Math.max(...polygonPoints.map((point) => point.y)),
+      }
+    }
+
+    if (
+      collidable.type === "pcb_smtpad" &&
+      collidable.shape === "rotated_pill"
+    ) {
+      const pill = getPillCenterLineForPad(collidable)
+      return {
+        minX: Math.min(pill.start.x, pill.end.x) - pill.radius,
+        minY: Math.min(pill.start.y, pill.end.y) - pill.radius,
+        maxX: Math.max(pill.start.x, pill.end.x) + pill.radius,
+        maxY: Math.max(pill.start.y, pill.end.y) + pill.radius,
       }
     }
   }

--- a/lib/check-each-pcb-trace-non-overlapping/segment-to-polygon-clearance.ts
+++ b/lib/check-each-pcb-trace-non-overlapping/segment-to-polygon-clearance.ts
@@ -10,6 +10,7 @@ import type { PcbPlatedHole, PcbSmtPad } from "circuit-json"
 import type { PcbTraceSegment } from "./getCollidableBounds"
 
 type PolygonalPad = PcbSmtPad | PcbPlatedHole
+type PillPad = Extract<PcbSmtPad, { shape: "pill" | "rotated_pill" }>
 
 const rotatePoint = (point: Point, angleDegrees: number): Point => {
   const angle = (angleDegrees * Math.PI) / 180
@@ -44,6 +45,25 @@ export const getRotatedRectPoints = ({
     const rotated = rotatePoint(point, ccwRotation)
     return { x: x + rotated.x, y: y + rotated.y }
   })
+}
+
+export const getPillCenterLineForPad = (pad: PillPad) => {
+  const ccwRotation = pad.shape === "rotated_pill" ? pad.ccw_rotation : 0
+  const halfLineLength = Math.max(
+    Math.max(pad.width, pad.height) / 2 - pad.radius,
+    0,
+  )
+  const axis =
+    pad.width >= pad.height
+      ? { x: halfLineLength, y: 0 }
+      : { x: 0, y: halfLineLength }
+  const rotatedAxis = rotatePoint(axis, ccwRotation)
+
+  return {
+    start: { x: pad.x - rotatedAxis.x, y: pad.y - rotatedAxis.y },
+    end: { x: pad.x + rotatedAxis.x, y: pad.y + rotatedAxis.y },
+    radius: pad.radius,
+  }
 }
 
 export const getPolygonPointsForPad = (pad: PolygonalPad): Point[] => {
@@ -135,13 +155,11 @@ const getClosestPointsBetweenSegments = (
   }
 }
 
-export const getSegmentToPolygonClearance = (
-  segment: PcbTraceSegment,
+export const getSegmentToPolygonClearanceFromPoints = (
+  start: Point,
+  end: Point,
   polygon: Point[],
 ) => {
-  const start = { x: segment.x1, y: segment.y1 }
-  const end = { x: segment.x2, y: segment.y2 }
-
   if (polygon.length < 3) {
     return { distance: Number.POSITIVE_INFINITY, center: start }
   }
@@ -196,4 +214,33 @@ export const getSegmentToPolygonClearance = (
   }
 
   return { distance: best.distance, center: best.center }
+}
+
+export const getSegmentToPolygonClearance = (
+  segment: PcbTraceSegment,
+  polygon: Point[],
+) =>
+  getSegmentToPolygonClearanceFromPoints(
+    { x: segment.x1, y: segment.y1 },
+    { x: segment.x2, y: segment.y2 },
+    polygon,
+  )
+
+export const getSegmentToPillClearance = (
+  segment: PcbTraceSegment,
+  pad: PillPad,
+) => {
+  const pill = getPillCenterLineForPad(pad)
+  const closest = getClosestPointsBetweenSegments(
+    { x: segment.x1, y: segment.y1 },
+    { x: segment.x2, y: segment.y2 },
+    pill.start,
+    pill.end,
+  )
+
+  return {
+    distance: closest.distance,
+    center: closest.center,
+    radius: pill.radius,
+  }
 }

--- a/lib/check-pad-clearance/common.ts
+++ b/lib/check-pad-clearance/common.ts
@@ -5,13 +5,22 @@ import {
   distanceBetweenPolygonAndPolygon,
   getBoundsOfPcbElements,
 } from "@tscircuit/circuit-json-util"
-import { midpoint } from "@tscircuit/math-utils"
+import {
+  midpoint,
+  segmentToCircleMinDistance,
+  segmentToSegmentMinDistance,
+} from "@tscircuit/math-utils"
 import type {
   AnyCircuitElement,
   PcbPlatedHole,
   PcbSmtPad,
   PcbTrace,
 } from "circuit-json"
+import {
+  getPillCenterLineForPad,
+  getPolygonPointsForPad,
+  getSegmentToPolygonClearanceFromPoints,
+} from "lib/check-each-pcb-trace-non-overlapping/segment-to-polygon-clearance"
 import type { PcbTraceSegment } from "lib/check-each-pcb-trace-non-overlapping/getCollidableBounds"
 import type { Bounds } from "lib/data-structures/SpatialIndex"
 import { DEFAULT_TRACE_THICKNESS } from "lib/drc-defaults"
@@ -41,6 +50,12 @@ export const getPadRadius = (pad: PadElement) => {
 
 export const isCircularPad = (pad: PadElement) => pad.shape === "circle"
 
+const isPillPad = (
+  pad: PadElement,
+): pad is Extract<PcbSmtPad, { shape: "pill" | "rotated_pill" }> =>
+  pad.type === "pcb_smtpad" &&
+  (pad.shape === "pill" || pad.shape === "rotated_pill")
+
 const getCircleShape = (pad: PadElement) => {
   const center = getPadCenter(pad)
   return {
@@ -52,6 +67,27 @@ const getCircleShape = (pad: PadElement) => {
 }
 
 const getPolygonShape = (pad: PadElement) => {
+  if (
+    pad.type === "pcb_smtpad" &&
+    (pad.shape === "polygon" || pad.shape === "rotated_rect")
+  ) {
+    return {
+      kind: "polygon" as const,
+      points: getPolygonPointsForPad(pad),
+    }
+  }
+
+  if (
+    pad.type === "pcb_plated_hole" &&
+    "rect_pad_width" in pad &&
+    "rect_pad_height" in pad
+  ) {
+    return {
+      kind: "polygon" as const,
+      points: getPolygonPointsForPad(pad),
+    }
+  }
+
   const bounds = getPadBounds(pad)
   return {
     kind: "polygon" as const,
@@ -65,6 +101,59 @@ const getPolygonShape = (pad: PadElement) => {
 }
 
 export const getPadToPadGap = (padA: PadElement, padB: PadElement) => {
+  if (isPillPad(padA) && isPillPad(padB)) {
+    const pillA = getPillCenterLineForPad(padA)
+    const pillB = getPillCenterLineForPad(padB)
+    return (
+      segmentToSegmentMinDistance(
+        pillA.start,
+        pillA.end,
+        pillB.start,
+        pillB.end,
+      ) -
+      pillA.radius -
+      pillB.radius
+    )
+  }
+
+  if (isPillPad(padA) && isCircularPad(padB)) {
+    const pill = getPillCenterLineForPad(padA)
+    return (
+      segmentToCircleMinDistance(pill.start, pill.end, getCircleShape(padB)) -
+      pill.radius
+    )
+  }
+
+  if (isCircularPad(padA) && isPillPad(padB)) {
+    const pill = getPillCenterLineForPad(padB)
+    return (
+      segmentToCircleMinDistance(pill.start, pill.end, getCircleShape(padA)) -
+      pill.radius
+    )
+  }
+
+  if (isPillPad(padA)) {
+    const pill = getPillCenterLineForPad(padA)
+    return (
+      getSegmentToPolygonClearanceFromPoints(
+        pill.start,
+        pill.end,
+        getPolygonShape(padB).points,
+      ).distance - pill.radius
+    )
+  }
+
+  if (isPillPad(padB)) {
+    const pill = getPillCenterLineForPad(padB)
+    return (
+      getSegmentToPolygonClearanceFromPoints(
+        pill.start,
+        pill.end,
+        getPolygonShape(padA).points,
+      ).distance - pill.radius
+    )
+  }
+
   if (isCircularPad(padA) && isCircularPad(padB)) {
     return distanceBetweenCircleAndCircle(
       getCircleShape(padA),

--- a/lib/check-pad-trace-clearance.ts
+++ b/lib/check-pad-trace-clearance.ts
@@ -12,6 +12,7 @@ import {
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
 import { getCollidableBounds } from "lib/check-each-pcb-trace-non-overlapping/getCollidableBounds"
+import { getSegmentToPillClearance } from "lib/check-each-pcb-trace-non-overlapping/segment-to-polygon-clearance"
 import { SpatialObjectIndex } from "lib/data-structures/SpatialIndex"
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
@@ -66,19 +67,28 @@ export function checkPadTraceClearance(
       if (connMap.areIdsConnected(segment.pcb_trace_id, padId)) continue
       const center = getPadCenter(pad)
 
-      const gap = isCircularPad(pad)
-        ? segmentToCircleMinDistance(
-            { x: segment.x1, y: segment.y1 },
-            { x: segment.x2, y: segment.y2 },
-            { x: center.x, y: center.y, radius: getPadRadius(pad) },
-          ) -
-          segment.thickness / 2
-        : segmentToBoundsMinDistance(
-            { x: segment.x1, y: segment.y1 },
-            { x: segment.x2, y: segment.y2 },
-            getPadBounds(pad),
-          ) -
-          segment.thickness / 2
+      const gap =
+        pad.type === "pcb_smtpad" && pad.shape === "rotated_pill"
+          ? (() => {
+              const { distance, radius } = getSegmentToPillClearance(
+                segment,
+                pad,
+              )
+              return distance - segment.thickness / 2 - radius
+            })()
+          : isCircularPad(pad)
+            ? segmentToCircleMinDistance(
+                { x: segment.x1, y: segment.y1 },
+                { x: segment.x2, y: segment.y2 },
+                { x: center.x, y: center.y, radius: getPadRadius(pad) },
+              ) -
+              segment.thickness / 2
+            : segmentToBoundsMinDistance(
+                { x: segment.x1, y: segment.y1 },
+                { x: segment.x2, y: segment.y2 },
+                getPadBounds(pad),
+              ) -
+              segment.thickness / 2
       if (gap + EPSILON >= minClearance!) continue
 
       const pairId = `${padId}_${segment.pcb_trace_id}`

--- a/lib/check-traces-are-contiguous/is-point-in-pad.ts
+++ b/lib/check-traces-are-contiguous/is-point-in-pad.ts
@@ -1,4 +1,6 @@
 import type { PcbSmtPad, PcbPlatedHole } from "circuit-json"
+import { pointToSegmentDistance } from "@tscircuit/math-utils"
+import { getPillCenterLineForPad } from "lib/check-each-pcb-trace-non-overlapping/segment-to-polygon-clearance"
 
 function getDistanceBetweenPoints(
   pointA: { x: number; y: number },
@@ -59,7 +61,14 @@ export function isPointInPad(
       )
     }
 
-    if (pad.shape === "pill") {
+    if (pad.shape === "pill" || pad.shape === "rotated_pill") {
+      if (pad.shape === "rotated_pill") {
+        const pill = getPillCenterLineForPad(pad)
+        return (
+          pointToSegmentDistance(point, pill.start, pill.end) <= pill.radius
+        )
+      }
+
       const halfWidth = pad.width / 2
       const halfHeight = pad.height / 2
       const radius = pad.radius

--- a/tests/lib/check-each-pcb-port-connected.test.ts
+++ b/tests/lib/check-each-pcb-port-connected.test.ts
@@ -2,6 +2,7 @@ import type { AnyCircuitElement, PcbTrace } from "circuit-json"
 import { expect, test, describe } from "bun:test"
 import { checkEachPcbPortConnectedToPcbTraces } from "lib/check-each-pcb-port-connected-to-pcb-trace"
 import { containsCircuitJsonId } from "lib/util/get-readable-names"
+import { addStartAndEndPortIdsIfMissing } from "lib/add-start-and-end-port-ids-if-missing"
 
 describe("checkEachPcbPortConnectedToPcbTraces", () => {
   test("should not return error for intentionally unconnected ports", () => {
@@ -368,5 +369,63 @@ describe("checkEachPcbPortConnectedToPcbTraces", () => {
     expect(updatedTrace.route[0].start_pcb_port_id).toBe("port1")
     // @ts-ignore
     expect(updatedTrace.route[1].end_pcb_port_id).toBe("port2")
+  })
+
+  test("should add port ids for endpoints inside rotated pill pads", () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_port",
+        pcb_port_id: "port1",
+        source_port_id: "source1",
+        x: 0,
+        y: 0,
+        pcb_component_id: "U3",
+        layers: ["top"],
+      },
+      {
+        type: "pcb_smtpad",
+        pcb_smtpad_id: "pad1",
+        pcb_port_id: "port1",
+        pcb_component_id: "U3",
+        shape: "rotated_pill",
+        x: 0,
+        y: 0,
+        width: 0.6299962,
+        height: 2.2500082,
+        radius: 0.3149981,
+        ccw_rotation: 90,
+        layer: "top",
+      },
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "trace1",
+        route: [
+          {
+            route_type: "wire",
+            x: 0.8,
+            y: 0,
+            width: 0.1,
+            layer: "top",
+          },
+          {
+            route_type: "wire",
+            x: 2,
+            y: 0,
+            width: 0.1,
+            layer: "top",
+          },
+        ],
+      },
+    ]
+
+    addStartAndEndPortIdsIfMissing(circuitJson)
+
+    const updatedTrace = circuitJson.find(
+      (item) => item.type === "pcb_trace",
+    ) as PcbTrace
+    const startPoint = updatedTrace.route[0]
+    expect(startPoint.route_type).toBe("wire")
+    if (startPoint.route_type !== "wire") throw new Error("Expected wire route")
+    expect(startPoint.start_pcb_port_id).toBe("port1")
   })
 })

--- a/tests/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.test.ts
+++ b/tests/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.test.ts
@@ -243,4 +243,33 @@ describe("checkEachPcbTraceNonOverlapping", () => {
       checkEachPcbTraceNonOverlapping(circuitJson, { minClearance: 0.1 }),
     ).toHaveLength(1)
   })
+
+  test("does not report false positives against a rotated pill pad bounding box", () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "trace1",
+        route: [
+          { route_type: "wire", x: -0.75, y: 0.7, width: 0.1, layer: "top" },
+          { route_type: "wire", x: -0.25, y: 0.7, width: 0.1, layer: "top" },
+        ],
+      },
+      {
+        type: "pcb_smtpad",
+        pcb_smtpad_id: "pad1",
+        shape: "rotated_pill",
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 0.4,
+        radius: 0.2,
+        ccw_rotation: 45,
+        layer: "top",
+      },
+    ]
+
+    expect(
+      checkEachPcbTraceNonOverlapping(circuitJson, { minClearance: 0.1 }),
+    ).toEqual([])
+  })
 })

--- a/tests/lib/check-pad-pad-clearance.test.ts
+++ b/tests/lib/check-pad-pad-clearance.test.ts
@@ -34,3 +34,23 @@ test("checkPadPadClearance reports pads closer than 0.2mm", () => {
   expect(errors[0].minimum_clearance).toBe(0.1)
   expect(errors[0].actual_clearance).toBeCloseTo(0.05, 10)
 })
+
+test("checkPadPadClearance does not flag adjacent W25Q16 rotated pill pads", () => {
+  const circuitJson: AnyCircuitElement[] = Array.from({ length: 4 }).map(
+    (_, index) => ({
+      type: "pcb_smtpad",
+      pcb_smtpad_id: `u3_pad_${index + 1}`,
+      pcb_component_id: "U3",
+      shape: "rotated_pill",
+      x: -2,
+      y: index * 1.27,
+      width: 0.6299962,
+      height: 2.2500082,
+      radius: 0.3149981,
+      ccw_rotation: 90,
+      layer: "top",
+    }),
+  )
+
+  expect(checkPadPadClearance(circuitJson)).toEqual([])
+})

--- a/tests/lib/check-pad-trace-clearance.test.ts
+++ b/tests/lib/check-pad-trace-clearance.test.ts
@@ -65,3 +65,30 @@ test("checkPadTraceClearance deduplicates multiple close segments for one pad-tr
   expect(errors[0].pcb_trace_id).toBe("trace1")
   expect(errors[0].actual_clearance).toBeCloseTo(0.075, 10)
 })
+
+test("checkPadTraceClearance ignores rotated pill pad bounding-box false positives", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "rotated_pill",
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 0.4,
+      radius: 0.2,
+      ccw_rotation: 45,
+      layer: "top",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace1",
+      route: [
+        { route_type: "wire", x: -0.75, y: 0.7, width: 0.1, layer: "top" },
+        { route_type: "wire", x: -0.25, y: 0.7, width: 0.1, layer: "top" },
+      ],
+    },
+  ]
+
+  expect(checkPadTraceClearance(circuitJson, { minClearance: 0.1 })).toEqual([])
+})

--- a/tests/lib/check-traces-are-contiguous.test.ts
+++ b/tests/lib/check-traces-are-contiguous.test.ts
@@ -6,6 +6,7 @@ import repro02 from "tests/assets/motor-controller-1.json"
 import type { AnyCircuitElement } from "circuit-json"
 import { runAllRoutingChecks } from "lib/run-all-checks"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
+import { isPointInPad } from "lib/check-traces-are-contiguous/is-point-in-pad"
 
 describe("testing checkTracesAreContiguous(", () => {
   test("should not error as traces are contiguous", () => {
@@ -179,6 +180,24 @@ test("does not report missing connection for ports with multiple smtpads includi
   expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
     import.meta.path,
   )
+})
+
+test("isPointInPad supports rotated pill pads", () => {
+  const pad = {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "rotated_pill_pad",
+    shape: "rotated_pill",
+    x: 0,
+    y: 0,
+    width: 0.6299962,
+    height: 2.2500082,
+    radius: 0.3149981,
+    ccw_rotation: 90,
+    layer: "top",
+  } as const
+
+  expect(isPointInPad({ x: 0.8, y: 0 }, pad)).toBe(true)
+  expect(isPointInPad({ x: 0, y: 0.8 }, pad)).toBe(false)
 })
 
 test("repro02 should report the J_VMOTOR GND trace disconnected endpoint", async () => {


### PR DESCRIPTION

Adds comprehensive geometric support for `rotated_pill` SMT pads throughout the PCB validation pipeline, replacing bounding-box approximations with accurate shape-aware calculations.

This PR includes:

* Rotated-pill pad containment checks for automatic port-to-trace association
* Accurate trace-to-pill clearance calculations
* Shape-aware pad-to-pad clearance analysis
* Rotated-pill support in trace overlap detection
* Specialized spatial bounds generation for pill geometries
* Shared pill centerline and clearance utilities
* Connectivity validation support for rotated-pill pad endpoints
* DRC improvements that eliminate bounding-box false positives
* Regression coverage for clearance, overlap, connectivity, and pad containment scenarios

This significantly improves routing and DRC accuracy for modern footprint libraries by ensuring rotated-pill pads are treated as true geometric shapes rather than rectangular approximations. 
<img width="906" height="679" alt="Screenshot 2026-06-17 at 7 32 57 AM" src="https://github.com/user-attachments/assets/f8fc75d0-fd3a-4846-b8e0-d5297beb25a6" />
