### PR TITLE
fix: handle non-rotated pill pads in trace clearance/overlap checks

### DIFF
--- a/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
+++ b/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
@@ -240,7 +240,10 @@ export function checkEachPcbTraceNonOverlapping(
         })
       }
 
-      if (obj.type === "pcb_smtpad" && obj.shape === "rotated_pill") {
+      if (
+        obj.type === "pcb_smtpad" &&
+        (obj.shape === "pill" || obj.shape === "rotated_pill")
+      ) {
         const { distance, center, radius } = getSegmentToPillClearance(
           segmentA,
           obj,

--- a/lib/check-pad-trace-clearance.ts
+++ b/lib/check-pad-trace-clearance.ts
@@ -68,7 +68,8 @@ export function checkPadTraceClearance(
       const center = getPadCenter(pad)
 
       const gap =
-        pad.type === "pcb_smtpad" && pad.shape === "rotated_pill"
+        pad.type === "pcb_smtpad" &&
+        (pad.shape === "pill" || pad.shape === "rotated_pill")
           ? (() => {
               const { distance, radius } = getSegmentToPillClearance(
                 segment,

--- a/tests/lib/check-pad-trace-clearance.test.ts
+++ b/tests/lib/check-pad-trace-clearance.test.ts
@@ -92,3 +92,59 @@ test("checkPadTraceClearance ignores rotated pill pad bounding-box false positiv
 
   expect(checkPadTraceClearance(circuitJson, { minClearance: 0.1 })).toEqual([])
 })
+
+test("checkPadTraceClearance ignores (non-rotated) pill pad bounding-box false positives", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "pill",
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 1,
+      radius: 0.5,
+      layer: "top",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace1",
+      // Near the rounded corner: bounding-box says contact, true pill gap is ~0.115mm.
+      route: [
+        { route_type: "wire", x: -1.07, y: 0.57, width: 0.1, layer: "top" },
+        { route_type: "wire", x: -0.97, y: 0.47, width: 0.1, layer: "top" },
+      ],
+    },
+  ]
+
+  expect(checkPadTraceClearance(circuitJson, { minClearance: 0.1 })).toEqual([])
+})
+
+test("checkPadTraceClearance still flags a real (non-rotated) pill pad clearance violation", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "pill",
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 1,
+      radius: 0.5,
+      layer: "top",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace1",
+      // Just above the flat edge (gap ~0.02mm < 0.1mm) -> must still be reported.
+      route: [
+        { route_type: "wire", x: -0.2, y: 0.57, width: 0.1, layer: "top" },
+        { route_type: "wire", x: 0.2, y: 0.57, width: 0.1, layer: "top" },
+      ],
+    },
+  ]
+
+  expect(
+    checkPadTraceClearance(circuitJson, { minClearance: 0.1 }),
+  ).toHaveLength(1)
+})


### PR DESCRIPTION
The trace-clearance and trace-overlap DRC checks only special-cased `rotated_pill` pads, so a plain `pill` pad fell through to axis-aligned **bounding-box** geometry — whose corners overstate the rounded pad by ~0.2mm. A trace routed cleanly near a pill pad's corner was wrongly flagged as a clearance violation / "accidental contact".
Fix: route plain `pill` pads through the existing pill-geometry path (`getSegmentToPillClearance` / `isPillPad`), exactly like `rotated_pill`.
Added regression tests: the rounded-corner false positive is ignored, and a real violation near the flat edge is still reported.

Closes #162