### PR TITLE
fix: declare runtime dependencies (@tscircuit/circuit-json-util, transformation-matrix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "format:check": "biome format .",
     "format": "biome format . --write"
   },
+  "dependencies": {
+    "transformation-matrix": "^3.1.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
     "@tscircuit/circuit-json-util": "^0.0.95",
@@ -29,6 +32,7 @@
   },
   "peerDependencies": {
     "@flatten-js/core": "*",
+    "@tscircuit/circuit-json-util": "*",
     "@tscircuit/math-utils": "*",
     "circuit-json": "*",
     "circuit-json-to-connectivity-map": "*",


### PR DESCRIPTION
## Problem

Clean install can't import the package — `bun add @tscircuit/checks` then `import "@tscircuit/checks"` throws `Cannot find module '@tscircuit/circuit-json-util'`.

Build is `tsup-node` (no bundling). The shipped `dist` imports `@tscircuit/circuit-json-util` (declared only in `devDependencies`, ×20 in `lib/`) and `transformation-matrix` (not declared, ×1).

## Fix

Per this repo's `dependency-check` (`internal_lib`): external → `dependencies`, internal `@tscircuit/*` → `peerDependencies` (`"*"`).

- `transformation-matrix` → `dependencies`
- `@tscircuit/circuit-json-util` → `peerDependencies` (`"*"`), kept pinned in `devDependencies`

`bunx @tscircuit/dependency-check` passes; build / format / test / type-check green.

## Verification

Built (`tsup-node`) and packed; clean install resolves. Full end-to-end import also needs the `circuit-json` root fix (tscircuit/circuit-json#633). Same class as tscircuit/dsn-converter#514, tscircuit/matchpack#150, tscircuit/calculate-packing#101.
