### PR TITLE
Fix rotated-pad and duplicate DRC reports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ export { checkPcbComponentOverlap } from "./lib/check-pcb-components-overlap/che
 export { checkPadPadClearance } from "./lib/check-pad-pad-clearance"
 export { checkPadTraceClearance } from "./lib/check-pad-trace-clearance"
 export { checkViaTraceClearance } from "./lib/check-via-trace-clearance"
+export { dedupePcbDrcErrors } from "./lib/dedupe-pcb-drc-errors"
 export { checkPinMustBeConnected } from "./lib/check-pin-must-be-connected"
 export { checkAllPinsInComponentAreUnderspecified } from "./lib/check-all-pins-in-component-are-underspecified"
 export { checkNoPowerPinDefined } from "./lib/check-no-power-pin-defined"

--- a/lib/check-traces-are-contiguous/is-point-in-pad.ts
+++ b/lib/check-traces-are-contiguous/is-point-in-pad.ts
@@ -1,6 +1,9 @@
 import type { PcbSmtPad, PcbPlatedHole } from "circuit-json"
 import { pointToSegmentDistance } from "@tscircuit/math-utils"
-import { getPillCenterLineForPad } from "lib/check-each-pcb-trace-non-overlapping/segment-to-polygon-clearance"
+import {
+  getPillCenterLineForPad,
+  getPolygonPointsForPad,
+} from "lib/check-each-pcb-trace-non-overlapping/segment-to-polygon-clearance"
 
 function getDistanceBetweenPoints(
   pointA: { x: number; y: number },
@@ -31,6 +34,24 @@ function isPointOnSegment(
   return dotProduct <= squaredLength + POINT_ON_SEGMENT_TOLERANCE_MM
 }
 
+function isPointInPolygon(
+  point: { x: number; y: number },
+  polygon: Array<{ x: number; y: number }>,
+): boolean {
+  let inside = false
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const pi = polygon[i]
+    const pj = polygon[j]
+    if (isPointOnSegment(point, { start: pi, end: pj })) return true
+
+    const intersects =
+      pi.y > point.y !== pj.y > point.y &&
+      point.x < ((pj.x - pi.x) * (point.y - pi.y)) / (pj.y - pi.y) + pi.x
+    if (intersects) inside = !inside
+  }
+  return inside
+}
+
 export function isPointInPad(
   point: { x: number; y: number },
   pad: PcbSmtPad | PcbPlatedHole,
@@ -50,15 +71,7 @@ export function isPointInPad(
     }
 
     if (pad.shape === "rotated_rect") {
-      const dx = point.x - pad.x
-      const dy = point.y - pad.y
-      const angle = -pad.ccw_rotation
-      const rotatedX = dx * Math.cos(angle) - dy * Math.sin(angle)
-      const rotatedY = dx * Math.sin(angle) + dy * Math.cos(angle)
-      return (
-        Math.abs(rotatedX) <= pad.width / 2 &&
-        Math.abs(rotatedY) <= pad.height / 2
-      )
+      return isPointInPolygon(point, getPolygonPointsForPad(pad))
     }
 
     if (pad.shape === "pill" || pad.shape === "rotated_pill") {
@@ -92,22 +105,7 @@ export function isPointInPad(
     }
 
     if (pad.shape === "polygon") {
-      let inside = false
-      for (
-        let i = 0, j = pad.points.length - 1;
-        i < pad.points.length;
-        j = i++
-      ) {
-        const pi = pad.points[i]
-        const pj = pad.points[j]
-        if (isPointOnSegment(point, { start: pi, end: pj })) return true
-
-        const intersects =
-          pi.y > point.y !== pj.y > point.y &&
-          point.x < ((pj.x - pi.x) * (point.y - pi.y)) / (pj.y - pi.y) + pi.x
-        if (intersects) inside = !inside
-      }
-      return inside
+      return isPointInPolygon(point, pad.points)
     }
   }
 
@@ -116,24 +114,14 @@ export function isPointInPad(
       return getDistanceBetweenPoints(point, pad) <= pad.outer_diameter / 2
     }
 
+    if ("rect_pad_width" in pad && "rect_pad_height" in pad) {
+      return isPointInPolygon(point, getPolygonPointsForPad(pad))
+    }
+
     if (pad.shape === "oval" || pad.shape === "pill") {
       return (
         Math.abs(point.x - pad.x) <= pad.outer_width / 2 &&
         Math.abs(point.y - pad.y) <= pad.outer_height / 2
-      )
-    }
-
-    if (pad.shape === "circular_hole_with_rect_pad") {
-      return (
-        Math.abs(point.x - pad.x) <= pad.rect_pad_width / 2 &&
-        Math.abs(point.y - pad.y) <= pad.rect_pad_height / 2
-      )
-    }
-
-    if (pad.shape === "pill_hole_with_rect_pad") {
-      return (
-        Math.abs(point.x - pad.x) <= pad.rect_pad_width / 2 &&
-        Math.abs(point.y - pad.y) <= pad.rect_pad_height / 2
       )
     }
   }

--- a/lib/dedupe-pcb-drc-errors.ts
+++ b/lib/dedupe-pcb-drc-errors.ts
@@ -1,0 +1,47 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+type DrcRecord = AnyCircuitElement & Record<string, unknown>
+
+/**
+ * Removes generic pcb_trace_error records when a more specific pad-trace or
+ * via-trace clearance error describes the same physical pair.
+ *
+ * The specific record is retained because it includes the measured and
+ * required clearance. Trace-trace and all other generic errors are untouched.
+ */
+export const dedupePcbDrcErrors = <T extends AnyCircuitElement>(
+  errors: T[],
+): T[] => {
+  const specificallyReportedPairIds = new Set<string>()
+
+  for (const error of errors as DrcRecord[]) {
+    if (
+      error.type === "pcb_pad_trace_clearance_error" &&
+      typeof error.pcb_trace_id === "string" &&
+      typeof error.pcb_pad_id === "string"
+    ) {
+      specificallyReportedPairIds.add(
+        `overlap_${error.pcb_trace_id}_${error.pcb_pad_id}`,
+      )
+    }
+
+    if (
+      error.type === "pcb_via_trace_clearance_error" &&
+      typeof error.pcb_trace_id === "string" &&
+      typeof error.pcb_via_id === "string"
+    ) {
+      specificallyReportedPairIds.add(
+        `overlap_${error.pcb_trace_id}_${error.pcb_via_id}`,
+      )
+    }
+  }
+
+  return errors.filter((element) => {
+    const error = element as DrcRecord
+    return !(
+      error.type === "pcb_trace_error" &&
+      typeof error.pcb_trace_error_id === "string" &&
+      specificallyReportedPairIds.has(error.pcb_trace_error_id)
+    )
+  })
+}

--- a/lib/run-all-checks.ts
+++ b/lib/run-all-checks.ts
@@ -18,6 +18,7 @@ import { checkSourceTracesHavePcbTraces } from "./check-source-traces-have-pcb-t
 import { checkPcbTracesOutOfBoard } from "./check-trace-out-of-board/checkTraceOutOfBoard"
 import { checkTracesAreContiguous } from "./check-traces-are-contiguous/check-traces-are-contiguous"
 import { checkViaTraceClearance } from "./check-via-trace-clearance"
+import { dedupePcbDrcErrors } from "./dedupe-pcb-drc-errors"
 
 export async function runAllPlacementChecks(circuitJson: AnyCircuitElement[]) {
   return [
@@ -46,7 +47,7 @@ export async function runAllPinSpecificationChecks(
 }
 
 export async function runAllRoutingChecks(circuitJson: AnyCircuitElement[]) {
-  return [
+  return dedupePcbDrcErrors([
     ...checkEachPcbPortConnectedToPcbTraces(circuitJson),
     ...checkSourceTracesHavePcbTraces(circuitJson),
     ...checkEachPcbTraceNonOverlapping(circuitJson),
@@ -55,14 +56,14 @@ export async function runAllRoutingChecks(circuitJson: AnyCircuitElement[]) {
     ...checkDifferentNetViaSpacing(circuitJson),
     ...checkTracesAreContiguous(circuitJson),
     ...checkPcbTracesOutOfBoard(circuitJson),
-  ]
+  ])
 }
 
 export async function runAllChecks(circuitJson: AnyCircuitElement[]) {
-  return [
+  return dedupePcbDrcErrors([
     ...(await runAllPlacementChecks(circuitJson)),
     ...(await runAllNetlistChecks(circuitJson)),
     ...(await runAllPinSpecificationChecks(circuitJson)),
     ...(await runAllRoutingChecks(circuitJson)),
-  ]
+  ])
 }

--- a/tests/lib/check-traces-are-contiguous-rotated-plated-hole.test.ts
+++ b/tests/lib/check-traces-are-contiguous-rotated-plated-hole.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { checkTracesAreContiguous } from "../../lib/check-traces-are-contiguous/check-traces-are-contiguous"
+
+test("trace endpoint in a rotated plated-hole rect pad is contiguous", () => {
+  const circuitJson = [
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "1",
+      pin_number: 1,
+      port_hints: ["1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      name: "2",
+      pin_number: 2,
+      port_hints: ["2"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_1",
+      source_port_id: "source_port_1",
+      x: 0,
+      y: 0,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_2",
+      source_port_id: "source_port_2",
+      x: 2,
+      y: 0,
+      layers: ["top"],
+    },
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "pcb_plated_hole_1",
+      pcb_port_id: "pcb_port_1",
+      shape: "rotated_pill_hole_with_rect_pad",
+      hole_shape: "rotated_pill",
+      pad_shape: "rect",
+      hole_width: 0.4,
+      hole_height: 0.8,
+      hole_ccw_rotation: 90,
+      rect_pad_width: 1.2,
+      rect_pad_height: 0.8,
+      rect_ccw_rotation: 90,
+      hole_offset_x: 0,
+      hole_offset_y: 0,
+      x: 0,
+      y: 0,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_2",
+      pcb_port_id: "pcb_port_2",
+      shape: "rect",
+      x: 2,
+      y: 0,
+      width: 0.4,
+      height: 0.4,
+      layer: "top",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_1",
+      source_trace_id: "source_trace_1",
+      route: [
+        {
+          route_type: "wire",
+          x: 0,
+          y: 0.5,
+          width: 0.1,
+          layer: "top",
+          start_pcb_port_id: "pcb_port_1",
+        },
+        {
+          route_type: "wire",
+          x: 2,
+          y: 0,
+          width: 0.1,
+          layer: "top",
+          end_pcb_port_id: "pcb_port_2",
+        },
+      ],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(checkTracesAreContiguous(circuitJson)).toEqual([])
+})

--- a/tests/lib/run-all-checks-dedupes-clearance-errors.test.ts
+++ b/tests/lib/run-all-checks-dedupes-clearance-errors.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { runAllChecks, runAllRoutingChecks } from "../.."
+
+test("runAllChecks reports typed pad and via clearance errors without generic duplicates", async () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "rect",
+      x: 0,
+      y: 0.2,
+      width: 0.2,
+      height: 0.2,
+      layer: "top",
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "via1",
+      x: 0.5,
+      y: 0.2,
+      hole_diameter: 0.2,
+      outer_diameter: 0.4,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace1",
+      route: [
+        { route_type: "wire", x: -1, y: 0, width: 0.1, layer: "top" },
+        { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
+      ],
+    },
+  ]
+
+  const errors = await runAllChecks(circuitJson)
+  const routingErrors = await runAllRoutingChecks(circuitJson)
+
+  expect(
+    errors.filter((error) => error.type === "pcb_pad_trace_clearance_error"),
+  ).toHaveLength(1)
+  expect(
+    errors.filter((error) => error.type === "pcb_via_trace_clearance_error"),
+  ).toHaveLength(1)
+  expect(
+    errors.filter(
+      (error) =>
+        error.type === "pcb_trace_error" &&
+        (error.pcb_trace_error_id === "overlap_trace1_pad1" ||
+          error.pcb_trace_error_id === "overlap_trace1_via1"),
+    ),
+  ).toHaveLength(0)
+  expect(
+    routingErrors.filter(
+      (error) =>
+        error.type === "pcb_trace_error" &&
+        error.pcb_trace_error_id === "overlap_trace1_via1",
+    ),
+  ).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

- use the real rotated copper-pad polygon when checking whether trace endpoints are inside rotated SMT pads and plated-hole rectangular pads
- add an exported DRC deduplication helper that prefers typed pad-trace and via-trace clearance errors over equivalent generic `pcb_trace_error` records
- apply deduplication to aggregate routing and all-check results without disabling any underlying collision check

## Root cause

`isPointInPad` did not support `rotated_pill_hole_with_rect_pad`, and its rotated SMT rectangle calculation treated degree values as radians. Valid trace endpoints inside those pads were therefore reported as disconnected.

Aggregate checks also combined the generic trace-overlap checker with the typed pad/via clearance checkers. The same physical trace/object pair could consequently be reported twice.

## Impact

The Dataset 18 analysis identified 112 false continuity errors and 898 duplicate records from these two causes. Replaying the affected continuity cases recognizes all 112 endpoints as contained by their related pads. Deduplication removes only generic records with a matching typed trace/object pair; trace-trace and unmatched errors remain unchanged.

## Validation

- `bun test` — 129 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run build`
- end-to-end autorouter sample 3: continuity false positives 24 → 0 and duplicates 13 → 0
- end-to-end autorouter sample 16: 53 raw reports → 29 physical issues, with all 29 physical issues retained
