### PR TITLE
Test checks for source-net-connected PCB vias

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/debug": "^4.1.12",
     "bun-match-svg": "^0.0.11",
     "circuit-json": "^0.0.457",
+    "circuit-json-to-connectivity-map": "^0.0.27",
     "circuit-to-svg": "^0.0.388",
     "debug": "^4.3.5",
     "format-si-unit": "^0.0.7",

--- a/tests/lib/check-each-pcb-trace-non-overlapping/vias-overlapping.test.ts
+++ b/tests/lib/check-each-pcb-trace-non-overlapping/vias-overlapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import type { PcbTrace, PcbVia } from "circuit-json"
+import type { AnyCircuitElement, PcbTrace, PcbVia } from "circuit-json"
 import { checkEachPcbTraceNonOverlapping } from "lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping"
 import { checkViaTraceClearance } from "lib/check-via-trace-clearance"
 
@@ -31,5 +31,55 @@ describe("PCB vias in non-overlapping trace checks", () => {
     expect(overlapErrors).toEqual([])
     expect(clearanceErrors).toHaveLength(1)
     expect(clearanceErrors[0]!.actual_clearance).toBeGreaterThan(0)
+  })
+
+  test("allows a trace to overlap a via assigned to the same source net", () => {
+    const testData = [
+      {
+        type: "source_net",
+        source_net_id: "source_net_gnd",
+        name: "GND",
+      },
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_gnd",
+        connected_source_port_ids: [],
+        connected_source_net_ids: ["source_net_gnd"],
+      },
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "pcb_trace_gnd",
+        source_trace_id: "source_trace_gnd",
+        route: [
+          {
+            x: 0,
+            y: 0,
+            width: 0.2,
+            layer: "top",
+            route_type: "wire",
+          },
+          {
+            x: 10,
+            y: 0,
+            width: 0.2,
+            layer: "top",
+            route_type: "wire",
+          },
+        ],
+      },
+      {
+        type: "pcb_via",
+        pcb_via_id: "pcb_via_gnd",
+        source_net_id: "source_net_gnd",
+        x: 5,
+        y: 0,
+        hole_diameter: 0.4,
+        outer_diameter: 0.6,
+        layers: ["top", "bottom"],
+      },
+    ] as AnyCircuitElement[]
+
+    expect(checkEachPcbTraceNonOverlapping(testData)).toEqual([])
+    expect(checkViaTraceClearance(testData)).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

- cover a PCB trace overlapping a via assigned directly through source_net_id
- verify same-net contact produces neither an overlap error nor a clearance error
- reproduce the live false-positive shape from the nRF52810 tracker
- add circuit-json-to-connectivity-map 0.0.27 as an explicit development dependency

Depends on merged tscircuit/circuit-json-to-connectivity-map#35.
Part of tscircuit/tscircuit#4205.

## Validation

- focused overlap/clearance regression passes
- build passes
- format check passes with its existing large-fixture notices
- git diff --check
