### PR TITLE
Follow insertion_direction rename to top/bottom

### DIFF
--- a/lib/check-connector-accessible-orientation.ts
+++ b/lib/check-connector-accessible-orientation.ts
@@ -17,11 +17,12 @@ function getFacingDirectionFromInsertionDirection(
       return "x-"
     case "from_right":
       return "x+"
-    case "from_front":
+    case "from_top":
       return "y+"
-    case "from_back":
+    case "from_bottom":
       return "y-"
     case "from_above":
+    case "from_below":
       return null
     default:
       return null

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/bun": "^1.2.8",
     "@types/debug": "^4.1.12",
     "bun-match-svg": "^0.0.11",
-    "circuit-json": "^0.0.457",
+    "circuit-json": "^0.0.461",
     "circuit-json-to-connectivity-map": "^0.0.27",
     "circuit-to-svg": "^0.0.388",
     "debug": "^4.3.5",

--- a/tests/lib/check-connector-accessible-orientation.test.tsx
+++ b/tests/lib/check-connector-accessible-orientation.test.tsx
@@ -194,7 +194,7 @@ test("connector orientation check uses insertion_direction when present", () => 
       height: 4,
       layer: "top",
       rotation: 0,
-      insertion_direction: "from_back",
+      insertion_direction: "from_bottom",
       obstructs_within_bounds: true,
     },
   ]


### PR DESCRIPTION
Circuit JSON renamed the +/-Y insertion directions from "from_front"/"from_back" to "from_top"/"from_bottom" and added "from_below" (-Z). Update the mapping to match, treating "from_below" like "from_above": neither constrains an in-plane facing direction, so both yield null.