### PR TITLE
fix: don't report derived connectivity findings when autorouting was skipped

### DIFF
--- a/lib/check-each-pcb-port-connected-to-pcb-trace.ts
+++ b/lib/check-each-pcb-port-connected-to-pcb-trace.ts
@@ -7,6 +7,7 @@ import type {
 import { addStartAndEndPortIdsIfMissing } from "./add-start-and-end-port-ids-if-missing"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { getReadableNameForPort } from "./util/get-readable-names"
+import { getSubcircuitIdsWithSkippedAutorouting } from "./util/get-subcircuits-with-skipped-autorouting"
 
 function checkEachPcbPortConnectedToPcbTraces(
   circuitJson: AnyCircuitElement[],
@@ -31,8 +32,19 @@ function checkEachPcbPortConnectedToPcbTraces(
     sourcePortToPcbPort.set(pcbPort.source_port_id, pcbPort)
   }
 
+  const skippedSubcircuitIds =
+    getSubcircuitIdsWithSkippedAutorouting(circuitJson)
+
   // Process each source trace
   for (const sourceTrace of sourceTraces) {
+    // The router never ran for this subcircuit, so an unconnected port here
+    // restates the placement error rather than being a separate failure.
+    if (
+      sourceTrace.subcircuit_id &&
+      skippedSubcircuitIds.has(sourceTrace.subcircuit_id)
+    ) {
+      continue
+    }
     const connectedSourcePortIds = sourceTrace.connected_source_port_ids
 
     // Skip traces with less than 2 ports (nothing to connect)

--- a/lib/check-source-traces-have-pcb-traces.ts
+++ b/lib/check-source-traces-have-pcb-traces.ts
@@ -7,6 +7,7 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { containsCircuitJsonId } from "lib/util/get-readable-names"
+import { getSubcircuitIdsWithSkippedAutorouting } from "lib/util/get-subcircuits-with-skipped-autorouting"
 
 /**
  * Check that each source_trace which connects source ports has at least one
@@ -30,8 +31,18 @@ function checkSourceTracesHavePcbTraces(
     pcbPorts.map((pcbPort) => [pcbPort.source_port_id, pcbPort]),
   )
   const connectivityMap = getFullConnectivityMapFromCircuitJson(circuitJson)
+  const skippedSubcircuitIds =
+    getSubcircuitIdsWithSkippedAutorouting(circuitJson)
 
   for (const sourceTrace of sourceTraces) {
+    // The router never ran for this subcircuit, so a missing pcb_trace here
+    // restates the placement error rather than being a separate failure.
+    if (
+      sourceTrace.subcircuit_id &&
+      skippedSubcircuitIds.has(sourceTrace.subcircuit_id)
+    ) {
+      continue
+    }
     if (!sourceTrace.connected_source_port_ids?.length) continue
     if ((sourceTrace.connected_source_net_ids?.length ?? 0) > 0) continue
     if (sourceTrace.connected_source_port_ids.length < 2) continue

--- a/lib/util/get-subcircuits-with-skipped-autorouting.ts
+++ b/lib/util/get-subcircuits-with-skipped-autorouting.ts
@@ -1,0 +1,33 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+/**
+ * Core inserts a pcb_autorouting_error with this id prefix when placement DRC
+ * errors make it skip autorouting for a whole subcircuit.
+ */
+const SKIPPED_FOR_PLACEMENT_ERRORS_PREFIX =
+  "pcb_autorouting_skipped_placement_errors_"
+
+/**
+ * Subcircuits whose autorouting was skipped outright because of placement
+ * errors. Their source traces have no pcb_trace because the router never ran,
+ * so connectivity findings for them are derived from the placement problem
+ * rather than being independent failures.
+ */
+export function getSubcircuitIdsWithSkippedAutorouting(
+  circuitJson: AnyCircuitElement[],
+): Set<string> {
+  const subcircuitIds = new Set<string>()
+  for (const element of circuitJson) {
+    if (element.type !== "pcb_autorouting_error") continue
+    const pcbErrorId = (element as any).pcb_error_id
+    if (
+      typeof pcbErrorId !== "string" ||
+      !pcbErrorId.startsWith(SKIPPED_FOR_PLACEMENT_ERRORS_PREFIX)
+    ) {
+      continue
+    }
+    const subcircuitId = (element as any).subcircuit_id
+    if (typeof subcircuitId === "string") subcircuitIds.add(subcircuitId)
+  }
+  return subcircuitIds
+}

--- a/tests/lib/skipped-autorouting-suppresses-derived-errors.test.ts
+++ b/tests/lib/skipped-autorouting-suppresses-derived-errors.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { runAllRoutingChecks } from "lib/run-all-checks"
+
+// A subcircuit whose autorouting core skipped because of placement errors:
+// the source trace has no pcb_trace, but only because the router never ran.
+const circuitJson = [
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_0",
+    subcircuit_id: "subcircuit_0",
+    connected_source_port_ids: ["source_port_0", "source_port_1"],
+    connected_source_net_ids: [],
+    display_name: ".R1 > .pin2 to .R2 > .pin1",
+  },
+  {
+    type: "pcb_port",
+    pcb_port_id: "pcb_port_0",
+    source_port_id: "source_port_0",
+    pcb_component_id: "pcb_component_0",
+    x: 0,
+    y: 0,
+    layers: ["top"],
+  },
+  {
+    type: "pcb_port",
+    pcb_port_id: "pcb_port_1",
+    source_port_id: "source_port_1",
+    pcb_component_id: "pcb_component_1",
+    x: 5,
+    y: 0,
+    layers: ["top"],
+  },
+] as unknown as AnyCircuitElement[]
+
+const skippedAutoroutingError = {
+  type: "pcb_autorouting_error",
+  pcb_error_id: "pcb_autorouting_skipped_placement_errors_subcircuit_0",
+  error_type: "pcb_autorouting_error",
+  subcircuit_id: "subcircuit_0",
+  message:
+    "Autorouting was skipped because 1 PCB placement error was found. Fix the placement errors or set placementDrcChecksDisabled to true to route anyway.",
+} as unknown as AnyCircuitElement
+
+test("reports missing traces when autorouting actually ran", async () => {
+  const findings = await runAllRoutingChecks(circuitJson)
+  const types = findings.map((f) => f.type)
+  expect(types).toContain("pcb_trace_missing_error")
+  expect(types).toContain("pcb_port_not_connected_error")
+})
+
+test("suppresses derived findings when autorouting was skipped for placement errors", async () => {
+  const findings = await runAllRoutingChecks([
+    ...circuitJson,
+    skippedAutoroutingError,
+  ])
+  const types = findings.map((f) => f.type)
+  expect(types).not.toContain("pcb_trace_missing_error")
+  expect(types).not.toContain("pcb_port_not_connected_error")
+})
+
+test("does not suppress findings for other subcircuits", async () => {
+  const findings = await runAllRoutingChecks([
+    ...circuitJson,
+    {
+      ...(skippedAutoroutingError as any),
+      pcb_error_id: "pcb_autorouting_skipped_placement_errors_subcircuit_9",
+      subcircuit_id: "subcircuit_9",
+    } as unknown as AnyCircuitElement,
+  ])
+  expect(findings.map((f) => f.type)).toContain("pcb_trace_missing_error")
+})
+
+test("does not suppress findings for unrelated autorouting errors", async () => {
+  const findings = await runAllRoutingChecks([
+    ...circuitJson,
+    {
+      type: "pcb_autorouting_error",
+      pcb_error_id: "pcb_autorouting_error_0",
+      error_type: "pcb_autorouting_error",
+      subcircuit_id: "subcircuit_0",
+      message: "cF ran out of iterations",
+    } as unknown as AnyCircuitElement,
+  ])
+  expect(findings.map((f) => f.type)).toContain("pcb_trace_missing_error")
+})


### PR DESCRIPTION
## Problem

Core skips autorouting for an entire subcircuit when it has placement errors, inserting

```
pcb_autorouting_error  pcb_autorouting_skipped_placement_errors_<subcircuit_id>
  "Autorouting was skipped because N PCB placement errors were found. ..."
```

Every source trace in that subcircuit then has no `pcb_trace`, so `checkSourceTracesHavePcbTraces` and `checkEachPcbPortConnectedToPcbTraces` each emit one finding per net. On a real board that means hundreds of `pcb_trace_missing_error` / `pcb_port_not_connected_error` entries pointing at nets that have nothing wrong with them, burying the one placement error that actually caused it.

Minimal shape of the confusion — a board with a single component sitting outside the outline and one unrelated, perfectly routable trace:

```
pcb_component_outside_board_error: Component R3 extends outside board boundaries...
pcb_autorouting_error:             Autorouting was skipped because 1 PCB placement error was found...
pcb_port_not_connected_error:      Ports [R1.pin2, R2.pin1] are not connected together through the same net.
pcb_trace_missing_error:           Trace [.R1 > .pin2 to .R2 > .pin1] is not connected (it has no PCB trace)
```

The last two describe R1/R2, which are fine. The router simply never ran.

## Fix

Skip those two checks for source traces belonging to a subcircuit whose autorouting was skipped this way.

Deliberately narrow, because suppressing findings is easy to get wrong:

- keyed to the `pcb_autorouting_skipped_placement_errors_` error id, not to autorouting errors generally — a router that ran and failed (`cF ran out of iterations`) still reports everything
- matched per `subcircuit_id`, so a skipped subcircuit never silences its siblings

Only the two checks that are pure consequences of "no traces exist" are touched; overlap, clearance and length checks are unaffected.

## Tests

`tests/lib/skipped-autorouting-suppresses-derived-errors.test.ts` covers the behaviour and both guardrails:

- findings still reported when autorouting ran
- findings suppressed for the skipped subcircuit
- **not** suppressed for a different subcircuit
- **not** suppressed for an unrelated autorouting error

Full suite: 145 pass.

## Related

- tscircuit/cli#4071 — `--ignore-placement-drc` doesn't currently lift the gate
- tscircuit/props#786 — `placementDrcChecksDisabled` isn't accepted on `<board>`, which is what the skip message tells users to set

🤖 Generated with [Claude Code](https://claude.com/claude-code)