### PR TITLE
Detect traces overlapping rotated pill plated holes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
-    "@tscircuit/circuit-json-util": "^0.0.95",
+    "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/jlcpcb-manufacturing-specs": "git+https://github.com/tscircuit/jlcpcb-manufacturing-specs#e08af159db01a37db007e33f0a7268d0e4a279a5",
     "@tscircuit/log-soup": "^1.0.2",
     "@types/bun": "^1.2.8",

--- a/tests/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.test.ts
+++ b/tests/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.test.ts
@@ -272,4 +272,50 @@ describe("checkEachPcbTraceNonOverlapping", () => {
       checkEachPcbTraceNonOverlapping(circuitJson, { minClearance: 0.1 }),
     ).toEqual([])
   })
+
+  test("reports a trace overlapping a rotated pill plated hole", () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "cc2_trace",
+        route: [
+          {
+            route_type: "wire",
+            x: -28.9,
+            y: -4.5,
+            width: 0.1,
+            layer: "top",
+          },
+          {
+            route_type: "wire",
+            x: -28.9,
+            y: -8.75,
+            width: 0.1,
+            layer: "top",
+          },
+        ],
+      },
+      {
+        type: "pcb_plated_hole",
+        pcb_plated_hole_id: "usb_shell_tab",
+        shape: "pill",
+        outer_width: 1.2,
+        outer_height: 1.8,
+        hole_width: 0.6,
+        hole_height: 1.2,
+        x: -28.125,
+        y: -7.075,
+        ccw_rotation: 270,
+        layers: ["top", "bottom"],
+      },
+    ]
+
+    const errors = checkEachPcbTraceNonOverlapping(circuitJson)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("overlaps with")
+    expect(errors[0].pcb_trace_id).toBe("cc2_trace")
+    expect(errors[0].pcb_component_ids).toEqual([])
+    expect(errors[0].pcb_port_ids).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

- update `@tscircuit/circuit-json-util` to `^0.0.106`
- add a regression test for a trace crossing a rotated pill-shaped USB shell tab

## Root cause

Pill and oval plated holes previously collapsed to a point when `checks` requested their bounds from `getBoundsOfPcbElements`. This could exclude the pad from the spatial collision query and allow a foreign-net trace to cross the copper without a DRC error.

`@tscircuit/circuit-json-util@0.0.106` supplies tight bounds based on `outer_width`, `outer_height`, and `ccw_rotation`.

## Impact

The trace-overlap check now considers rotated pill plated-hole copper and reports the reproduced USB shell-tab collision.

## Validation

- `bun test` — 142 tests passed
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`
