### PR TITLE
Consume the shared millimetre formatter

### DIFF
--- a/lib/check-pad-clearance/common.ts
+++ b/lib/check-pad-clearance/common.ts
@@ -31,11 +31,6 @@ import { DEFAULT_TRACE_THICKNESS } from "lib/drc-defaults"
 export type PadElement = PcbSmtPad | PcbPlatedHole
 export type PadClearanceElement = PadElement | PcbVia
 
-export const formatMm = (value: number) => {
-  const rounded = Math.round(value * 1000) / 1000
-  return `${Number(rounded.toFixed(3))}mm`
-}
-
 export const getPadBounds = (pad: PadClearanceElement): Bounds =>
   getBoundsOfPcbElements([pad])
 

--- a/lib/check-pad-pad-clearance.ts
+++ b/lib/check-pad-pad-clearance.ts
@@ -3,6 +3,7 @@ import {
   getReadableNameForElement,
 } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, PcbPadPadClearanceError } from "circuit-json"
+import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
@@ -12,7 +13,6 @@ import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import {
   type PadElement,
-  formatMm,
   getPadBounds,
   getPadCenter,
   getPadToPadGap,

--- a/lib/check-pad-trace-clearance.ts
+++ b/lib/check-pad-trace-clearance.ts
@@ -4,6 +4,7 @@ import {
 } from "@tscircuit/circuit-json-util"
 import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 import type { AnyCircuitElement, PcbPadTraceClearanceError } from "circuit-json"
+import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
@@ -14,7 +15,6 @@ import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import {
   type PadElement,
-  formatMm,
   getPadBounds,
   getPads,
   getTraceCenter,

--- a/lib/check-via-pad-clearance.ts
+++ b/lib/check-via-pad-clearance.ts
@@ -8,6 +8,7 @@ import type {
   PcbPadPadClearanceError,
   PcbVia,
 } from "circuit-json"
+import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
@@ -17,7 +18,6 @@ import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import {
   type PadElement,
-  formatMm,
   getPadBounds,
   getPadCenter,
   getPadToPadGap,

--- a/lib/check-via-trace-clearance.ts
+++ b/lib/check-via-trace-clearance.ts
@@ -5,6 +5,7 @@ import type {
   PcbVia,
   PcbViaTraceClearanceError,
 } from "circuit-json"
+import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
@@ -12,7 +13,6 @@ import {
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import {
-  formatMm,
   getTraceCenter,
   getTraceObstacleClearance,
   getTraceSegments,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "circuit-json-to-connectivity-map": "^0.0.27",
     "circuit-to-svg": "^0.0.388",
     "debug": "^4.3.5",
-    "format-si-unit": "^0.0.7",
+    "format-si-unit": "^0.0.12",
     "tscircuit": "^0.0.1786",
     "tsup": "^8.2.3",
     "zod": "^3.23.8"


### PR DESCRIPTION
Imports `formatMm` directly from `format-si-unit@0.0.12` at each DRC call site.

Removes the checks-local implementation completely; `checks` no longer exports or re-exports `formatMm`. The formatter now has one owner in `format-si-unit`.

All 143 tests, typecheck, build, format, dependency, and duplicate-helper gates pass.