### PR TITLE
Check copper pours against board edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and output an array of arrays for any issues found.
 | [`checkSourceTracesHavePcbTraces`](./lib/check-source-traces-have-pcb-traces.ts) | Returns `pcb_trace_error` when source traces are missing corresponding `pcb_trace` routes. |
 | [`checkTracesAreContiguous`](./lib/check-traces-are-contiguous/check-traces-are-contiguous.ts) | Returns `pcb_trace_error` when trace endpoints are floating or do not connect as expected. |
 | [`checkViasOffBoard`](./lib/check-pcb-components-out-of-board/checkViasOffBoard.ts) | Returns `pcb_placement_error` if any PCB via lies outside or crosses the board boundary. |
-| [`checkCopperToBoardEdgeClearance`](./lib/check-copper-to-board-edge-clearance.ts) | Checks via, SMT-pad, and plated-hole copper against the polygon board outline and required edge clearance. |
+| [`checkCopperToBoardEdgeClearance`](./lib/check-copper-to-board-edge-clearance.ts) | Checks via, SMT-pad, plated-hole, and copper-pour geometry against the polygon board outline and required edge clearance. |
 
 ## Aggregate check runner functions
 

--- a/lib/check-copper-to-board-edge-clearance.ts
+++ b/lib/check-copper-to-board-edge-clearance.ts
@@ -4,6 +4,7 @@ import type {
   AnyCircuitElement,
   PcbBoard,
   PcbComponent,
+  PcbCopperPour,
   PcbPlacementError,
   PcbPlatedHole,
   PcbSmtPad,
@@ -12,7 +13,7 @@ import type {
 import { getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { applyToPoint, rotateDEG } from "transformation-matrix"
 
-type CopperElement = PcbVia | PcbSmtPad | PcbPlatedHole
+type CopperElement = PcbVia | PcbSmtPad | PcbPlatedHole | PcbCopperPour
 declare const pcbComponentIdBrand: unique symbol
 type PcbComponentId = string & {
   readonly [pcbComponentIdBrand]: "PcbComponentId"
@@ -31,6 +32,71 @@ const pointsToPolygon = (
 ): Flatten.Polygon | null => {
   if (points.length < 3) return null
   return new Flatten.Polygon(points.map(({ x, y }) => new Flatten.Point(x, y)))
+}
+
+const brepRingToPolygon = (
+  vertices: Array<{ x: number; y: number; bulge?: number }>,
+): Flatten.Polygon | null => {
+  const ring = vertices.filter((vertex, index) => {
+    const previous = vertices[index - 1]
+    return (
+      !previous ||
+      Math.abs(previous.x - vertex.x) > GEOMETRY_EPSILON ||
+      Math.abs(previous.y - vertex.y) > GEOMETRY_EPSILON
+    )
+  })
+  if (
+    ring.length > 1 &&
+    Math.abs(ring[0].x - ring.at(-1)!.x) <= GEOMETRY_EPSILON &&
+    Math.abs(ring[0].y - ring.at(-1)!.y) <= GEOMETRY_EPSILON
+  ) {
+    ring.pop()
+  }
+  if (ring.length < 3) return null
+
+  const edges: Array<Flatten.Segment | Flatten.Arc> = []
+  for (let index = 0; index < ring.length; index++) {
+    const start = ring[index]
+    const end = ring[(index + 1) % ring.length]
+    const startPoint = new Flatten.Point(start.x, start.y)
+    const endPoint = new Flatten.Point(end.x, end.y)
+    const bulge = start.bulge ?? 0
+    if (Math.abs(bulge) <= GEOMETRY_EPSILON) {
+      edges.push(new Flatten.Segment(startPoint, endPoint))
+      continue
+    }
+
+    const chordLength = startPoint.distanceTo(endPoint)[0]
+    if (chordLength <= GEOMETRY_EPSILON) continue
+    const midpoint = {
+      x: (start.x + end.x) / 2,
+      y: (start.y + end.y) / 2,
+    }
+    const leftNormal = {
+      x: -(end.y - start.y) / chordLength,
+      y: (end.x - start.x) / chordLength,
+    }
+    const centerOffset = (chordLength * (1 - bulge * bulge)) / (4 * bulge)
+    const center = new Flatten.Point(
+      midpoint.x + leftNormal.x * centerOffset,
+      midpoint.y + leftNormal.y * centerOffset,
+    )
+    const radius = (chordLength * (1 + bulge * bulge)) / (4 * Math.abs(bulge))
+    edges.push(
+      new Flatten.Arc(
+        center,
+        radius,
+        Math.atan2(start.y - center.y, start.x - center.x),
+        Math.atan2(end.y - center.y, end.x - center.x),
+        bulge > 0,
+      ),
+    )
+  }
+
+  if (edges.length < 3) return null
+  const polygon = new Flatten.Polygon()
+  polygon.addFace(edges)
+  return polygon
 }
 
 const boardToPolygon = (board: PcbBoard): Flatten.Polygon | null => {
@@ -325,26 +391,51 @@ const getCopperGeometry = (
     }
   }
   if (element.type === "pcb_smtpad") return getSmtPadGeometry(element)
-  return getPlatedHoleGeometry(
-    element,
-    element.pcb_component_id
-      ? (componentCcwRotationsById.get(
-          toPcbComponentId(element.pcb_component_id),
-        ) ?? 0)
-      : 0,
-  )
+  if (element.type === "pcb_plated_hole") {
+    return getPlatedHoleGeometry(
+      element,
+      element.pcb_component_id
+        ? (componentCcwRotationsById.get(
+            toPcbComponentId(element.pcb_component_id),
+          ) ?? 0)
+        : 0,
+    )
+  }
+
+  let polygon: Flatten.Polygon | null
+  switch (element.shape) {
+    case "rect":
+      polygon = getRectanglePolygon({
+        x: element.center.x,
+        y: element.center.y,
+        width: element.width,
+        height: element.height,
+        ccwRotationDegrees: element.rotation ?? 0,
+      })
+      break
+    case "polygon":
+      polygon = pointsToPolygon(element.points)
+      break
+    case "brep":
+      // Holes remove copper, so only the outer ring can violate the board edge.
+      polygon = brepRingToPolygon(element.brep_shape.outer_ring.vertices)
+      break
+  }
+  return polygon ? { kind: "shapes", shapes: [polygon] } : null
 }
 
 const getCopperElementId = (element: CopperElement): string => {
   if (element.type === "pcb_via") return element.pcb_via_id
   if (element.type === "pcb_smtpad") return element.pcb_smtpad_id
-  return element.pcb_plated_hole_id
+  if (element.type === "pcb_plated_hole") return element.pcb_plated_hole_id
+  return element.pcb_copper_pour_id
 }
 
 const getCopperElementLabel = (element: CopperElement): string => {
   if (element.type === "pcb_via") return "Via"
   if (element.type === "pcb_smtpad") return "SMT pad"
-  return "Plated hole"
+  if (element.type === "pcb_plated_hole") return "Plated hole"
+  return "Copper pour"
 }
 
 const measureClearance = (
@@ -374,8 +465,9 @@ const measureClearance = (
 }
 
 /**
- * Checks the finished copper geometry of every via, SMT pad, and plated hole
- * against the real board outline and its configured edge-clearance rule.
+ * Checks the finished copper geometry of every via, SMT pad, plated hole, and
+ * copper pour against the real board outline and its configured edge-clearance
+ * rule.
  *
  * Component and footprint rotations are normally composed into Circuit JSON's
  * absolute coordinates and `ccw_rotation` fields. Polygon-pad plated holes are
@@ -400,7 +492,8 @@ export function checkCopperToBoardEdgeClearance(
     (element): element is CopperElement =>
       element.type === "pcb_via" ||
       element.type === "pcb_smtpad" ||
-      element.type === "pcb_plated_hole",
+      element.type === "pcb_plated_hole" ||
+      element.type === "pcb_copper_pour",
   )
   const componentCcwRotationsById = new Map<PcbComponentId, number>(
     circuitJson

--- a/tests/lib/check-copper-to-board-edge-clearance.test.ts
+++ b/tests/lib/check-copper-to-board-edge-clearance.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import { convertCircuitJsonToPcbSvg } from "circuit-to-svg"
-import type { AnyCircuitElement, PcbPlatedHole, PcbSmtPad } from "circuit-json"
+import type {
+  AnyCircuitElement,
+  PcbCopperPour,
+  PcbPlatedHole,
+  PcbSmtPad,
+} from "circuit-json"
 import { checkCopperToBoardEdgeClearance } from "lib/check-copper-to-board-edge-clearance"
 import { checkViasOffBoard } from "lib/check-pcb-components-out-of-board/checkViasOffBoard"
 import { runAllPlacementChecks } from "lib/run-all-checks"
@@ -187,6 +192,120 @@ test.each(violatingSmtPads)("supports $shape SMT copper geometry", (pad) => {
 
   expect(errors).toHaveLength(1)
   expect(errors[0].message).toContain(pad.pcb_smtpad_id)
+})
+
+const violatingCopperPours: PcbCopperPour[] = [
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "rect_pour_outside_board",
+    shape: "rect",
+    center: { x: 4.5, y: 0 },
+    width: 1,
+    height: 2,
+    rotation: 45,
+    layer: "top",
+    covered_with_solder_mask: true,
+  },
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "polygon_pour_outside_board",
+    shape: "polygon",
+    points: [
+      { x: 4, y: -1 },
+      { x: 5.2, y: 0 },
+      { x: 4, y: 1 },
+    ],
+    layer: "top",
+    covered_with_solder_mask: true,
+  },
+  {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "brep_pour_outside_board",
+    shape: "brep",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          { x: -1, y: -5.2 },
+          { x: 1, y: -5.2 },
+          { x: 1, y: -4 },
+          { x: -1, y: -4 },
+        ],
+      },
+      inner_rings: [],
+    },
+    layer: "bottom",
+    covered_with_solder_mask: true,
+  },
+]
+
+test.each(violatingCopperPours)(
+  "detects $shape copper pours outside the board",
+  (pour) => {
+    const errors = checkCopperToBoardEdgeClearance([rectangularBoard, pour])
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain(pour.pcb_copper_pour_id)
+    expect(errors[0].message).toContain("measured 0.000mm")
+  },
+)
+
+test("detects a curved BRep copper edge outside the board", () => {
+  const curvedPour: PcbCopperPour = {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "curved_brep_pour_outside_board",
+    shape: "brep",
+    brep_shape: {
+      outer_ring: {
+        vertices: [
+          // Both endpoints are inside, but this bulge bows past x=5.
+          { x: 4.5, y: -1, bulge: 0.75 },
+          { x: 4.5, y: 1 },
+          { x: 3.5, y: 1 },
+          { x: 3.5, y: -1 },
+        ],
+      },
+      inner_rings: [],
+    },
+    layer: "top",
+    covered_with_solder_mask: true,
+  }
+
+  const errors = checkCopperToBoardEdgeClearance([rectangularBoard, curvedPour])
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain(curvedPour.pcb_copper_pour_id)
+  expect(errors[0].message).toContain("measured 0.000mm")
+})
+
+test("accepts copper pours at or above the required board-edge clearance", () => {
+  const pour: PcbCopperPour = {
+    type: "pcb_copper_pour",
+    pcb_copper_pour_id: "pour_at_required_clearance",
+    shape: "rect",
+    center: { x: 0, y: 0 },
+    width: 9.6,
+    height: 9.6,
+    rotation: 0,
+    layer: "top",
+    covered_with_solder_mask: true,
+  }
+
+  expect(checkCopperToBoardEdgeClearance([rectangularBoard, pour])).toEqual([])
+})
+
+test("reports copper pours through runAllPlacementChecks", async () => {
+  const errors = await runAllPlacementChecks([
+    rectangularBoard,
+    violatingCopperPours[0],
+  ])
+
+  expect(errors).toContainEqual(
+    expect.objectContaining({
+      type: "pcb_placement_error",
+      pcb_placement_error_id:
+        "copper_too_close_to_board_edge_rect_pour_outside_board",
+    }),
+  )
 })
 
 test("supports rotated oval plated-hole copper geometry", () => {


### PR DESCRIPTION
## What changed

- extend `checkCopperToBoardEdgeClearance` to include `pcb_copper_pour` elements
- support rectangular, polygon, and BRep pours, including BRep bulge arcs
- report violations through the existing placement-check pipeline
- document the additional copper geometry covered by the check

## Why

Copper-pour outlines can extend beyond a resized board without producing a placement error. The existing board-edge check covered vias, SMT pads, and plated holes, but omitted copper pours entirely.

## Impact

Designs now receive a `pcb_placement_error` when a copper pour is outside the board outline or violates `min_board_edge_clearance`. Pours at or above the configured clearance continue to pass.

## Validation

- `bun test` — 174 passing
- `bun run build`
- `bunx tsc --noEmit`
- `git diff --check`
