### PR TITLE
Migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/pver-release.yml
+++ b/.github/workflows/pver-release.yml
@@ -6,6 +6,11 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
   UPSTREAM_REPOS: "core"
   UPSTREAM_PACKAGES_TO_UPDATE: "@tscircuit/checks"
@@ -21,16 +26,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
       - name: Trigger upstream repo updates
         if: env.UPSTREAM_REPOS && env.UPSTREAM_PACKAGES_TO_UPDATE

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "main": "./dist/index.js",
   "version": "0.0.163",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/checks"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
- use npm trusted publishing with GitHub Actions OIDC instead of a long-lived NPM_TOKEN
- grant id-token: write and run Node 24 with npm 11+ support
- declare an explicit GitHub repository URL in package metadata where needed

## Required npm configuration
Before merge, the npm package must trust:
- GitHub repository: tscircuit/checks
- Workflow: pver-release.yml
- Allowed action: npm publish

## Validation
- package.json parsed successfully
- release workflow parsed successfully
- git diff --check