### PR TITLE
Validate LED schematic ports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ export { checkPcbTracesOutOfBoard } from "./lib/check-trace-out-of-board/checkTr
 export { checkPcbComponentOverlap } from "./lib/check-pcb-components-overlap/checkPcbComponentOverlap"
 export { checkPcbComponentsMissingCourtyard } from "./lib/check-pcb-components-missing-courtyard"
 export { checkPcbTraceLengths } from "./lib/check-pcb-trace-lengths"
+export { checkLedSchematicPorts } from "./lib/check-led-schematic-ports"
 export { checkPadPadClearance } from "./lib/check-pad-pad-clearance"
 export { checkPadTraceClearance } from "./lib/check-pad-trace-clearance"
 export { checkViaTraceClearance } from "./lib/check-via-trace-clearance"

--- a/lib/check-led-schematic-ports.ts
+++ b/lib/check-led-schematic-ports.ts
@@ -1,0 +1,76 @@
+import type {
+  AnyCircuitElement,
+  SchematicComponent,
+  SchematicError,
+  SchematicPort,
+  SourcePort,
+  SourceSimpleLed,
+} from "circuit-json"
+
+/** Ensure every LED source port has a matching schematic port. */
+export const checkLedSchematicPorts = (
+  circuitJson: AnyCircuitElement[],
+): SchematicError[] => {
+  const leds = circuitJson.filter(
+    (element): element is SourceSimpleLed =>
+      element.type === "source_component" && element.ftype === "simple_led",
+  )
+  const sourcePorts = circuitJson.filter(
+    (element): element is SourcePort => element.type === "source_port",
+  )
+  const schematicComponents = circuitJson.filter(
+    (element): element is SchematicComponent =>
+      element.type === "schematic_component",
+  )
+  const schematicPorts = circuitJson.filter(
+    (element): element is SchematicPort => element.type === "schematic_port",
+  )
+
+  const errors: SchematicError[] = []
+
+  for (const led of leds) {
+    const schematicComponent = schematicComponents.find(
+      (component) => component.source_component_id === led.source_component_id,
+    )
+    if (!schematicComponent) {
+      errors.push({
+        type: "schematic_error",
+        schematic_error_id: `led_missing_schematic_component_${led.source_component_id}`,
+        error_type: "schematic_port_not_found",
+        message: `LED ${led.name} does not have a schematic component`,
+        subcircuit_id: led.subcircuit_id,
+      })
+      continue
+    }
+
+    const ledSourcePortIds = sourcePorts
+      .filter(
+        (sourcePort) =>
+          sourcePort.source_component_id === led.source_component_id,
+      )
+      .map((sourcePort) => sourcePort.source_port_id)
+    const representedSourcePortIds = new Set(
+      schematicPorts
+        .filter(
+          (schematicPort) =>
+            schematicPort.schematic_component_id ===
+            schematicComponent.schematic_component_id,
+        )
+        .map((schematicPort) => schematicPort.source_port_id),
+    )
+    const missingSourcePortIds = ledSourcePortIds.filter(
+      (sourcePortId) => !representedSourcePortIds.has(sourcePortId),
+    )
+    if (missingSourcePortIds.length === 0) continue
+
+    errors.push({
+      type: "schematic_error",
+      schematic_error_id: `led_missing_schematic_ports_${led.source_component_id}`,
+      error_type: "schematic_port_not_found",
+      message: `LED ${led.name} is missing ${missingSourcePortIds.length} schematic port${missingSourcePortIds.length === 1 ? "" : "s"}`,
+      subcircuit_id: led.subcircuit_id,
+    })
+  }
+
+  return errors
+}

--- a/lib/run-all-checks.ts
+++ b/lib/run-all-checks.ts
@@ -6,6 +6,7 @@ import { checkCourtyardOverlap } from "./check-courtyard-overlap/checkCourtyardO
 import { checkDifferentNetViaSpacing } from "./check-different-net-via-spacing"
 import { checkEachPcbPortConnectedToPcbTraces } from "./check-each-pcb-port-connected-to-pcb-trace"
 import { checkEachPcbTraceNonOverlapping } from "./check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping"
+import { checkLedSchematicPorts } from "./check-led-schematic-ports"
 import { checkNoGroundPinDefined } from "./check-no-ground-pin-defined"
 import { checkNoPowerPinDefined } from "./check-no-power-pin-defined"
 import { checkPadPadClearance } from "./check-pad-pad-clearance"
@@ -46,7 +47,10 @@ export async function runAllNetlistChecks(circuitJson: AnyCircuitElement[]) {
 }
 
 export async function runAllSchematicChecks(circuitJson: AnyCircuitElement[]) {
-  return checkSchematicComponentExcessiveVerticalPadding(circuitJson)
+  return [
+    ...checkSchematicComponentExcessiveVerticalPadding(circuitJson),
+    ...checkLedSchematicPorts(circuitJson),
+  ]
 }
 
 export async function runAllPinSpecificationChecks(

--- a/tests/lib/check-led-schematic-ports.test.ts
+++ b/tests/lib/check-led-schematic-ports.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { checkLedSchematicPorts } from "lib/check-led-schematic-ports"
+import { runAllSchematicChecks } from "lib/run-all-checks"
+
+const createLedCircuitJson = (
+  representedSourcePortIds: string[],
+): AnyCircuitElement[] => [
+  {
+    type: "source_component",
+    source_component_id: "source_component_led1",
+    name: "LED1",
+    ftype: "simple_led",
+  },
+  ...[1, 2].map(
+    (pinNumber): AnyCircuitElement => ({
+      type: "source_port",
+      source_port_id: `source_port_led1_${pinNumber}`,
+      source_component_id: "source_component_led1",
+      name: `pin${pinNumber}`,
+      pin_number: pinNumber,
+      port_hints: [`pin${pinNumber}`],
+    }),
+  ),
+  {
+    type: "schematic_component",
+    schematic_component_id: "schematic_component_led1",
+    source_component_id: "source_component_led1",
+    center: { x: 0, y: 0 },
+    size: { width: 1, height: 1 },
+    is_box_with_pins: true,
+    symbol_name: "led_right",
+  },
+  ...representedSourcePortIds.map(
+    (sourcePortId, index): AnyCircuitElement => ({
+      type: "schematic_port",
+      schematic_port_id: `schematic_port_led1_${index + 1}`,
+      source_port_id: sourcePortId,
+      schematic_component_id: "schematic_component_led1",
+      center: { x: index, y: 0 },
+    }),
+  ),
+]
+
+test("errors when an LED symbol is missing schematic ports", async () => {
+  const circuitJson = createLedCircuitJson([])
+
+  expect(checkLedSchematicPorts(circuitJson)).toEqual([
+    expect.objectContaining({
+      type: "schematic_error",
+      error_type: "schematic_port_not_found",
+    }),
+  ])
+  expect(await runAllSchematicChecks(circuitJson)).toEqual(
+    expect.arrayContaining(checkLedSchematicPorts(circuitJson)),
+  )
+})
+
+test("errors when an LED has no schematic component", () => {
+  const circuitJson = createLedCircuitJson([]).filter(
+    (element) =>
+      element.type !== "schematic_component" &&
+      element.type !== "schematic_port",
+  )
+
+  expect(checkLedSchematicPorts(circuitJson)).toEqual([
+    expect.objectContaining({
+      type: "schematic_error",
+      message: "LED LED1 does not have a schematic component",
+    }),
+  ])
+})
+
+test("accepts an LED whose two source ports are represented", () => {
+  const circuitJson = createLedCircuitJson([
+    "source_port_led1_1",
+    "source_port_led1_2",
+  ])
+
+  expect(checkLedSchematicPorts(circuitJson)).toEqual([])
+})


### PR DESCRIPTION
## Summary

- report a schematic error when an LED has no schematic component
- report a schematic error when LED source ports are missing from its symbol
- run the validation alongside existing schematic checks

## Tests

- `bun test tests/lib/check-led-schematic-ports.test.ts`
- `bunx tsc --noEmit`
- `bun run build`