### PR TITLE
Validate per-trace maximum via counts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ export { checkPcbTracesOutOfBoard } from "./lib/check-trace-out-of-board/checkTr
 export { checkPcbComponentOverlap } from "./lib/check-pcb-components-overlap/checkPcbComponentOverlap"
 export { checkPcbComponentsMissingCourtyard } from "./lib/check-pcb-components-missing-courtyard"
 export { checkPcbTraceLengths } from "./lib/check-pcb-trace-lengths"
+export { checkPcbTraceViaCounts } from "./lib/check-pcb-trace-via-counts"
 export { checkPadPadClearance } from "./lib/check-pad-pad-clearance"
 export { checkPadTraceClearance } from "./lib/check-pad-trace-clearance"
 export { checkViaTraceClearance } from "./lib/check-via-trace-clearance"

--- a/lib/check-pcb-trace-via-counts.ts
+++ b/lib/check-pcb-trace-via-counts.ts
@@ -1,0 +1,71 @@
+import type {
+  AnyCircuitElement,
+  PcbPort,
+  PcbTrace,
+  PcbTraceError,
+  SourceTrace,
+} from "circuit-json"
+
+/** Return a routing error when a source trace exceeds its maximum via count. */
+export const checkPcbTraceViaCounts = (
+  circuitJson: AnyCircuitElement[],
+): PcbTraceError[] => {
+  const sourceTraces = circuitJson.filter(
+    (element): element is SourceTrace => element.type === "source_trace",
+  )
+  const pcbTraces = circuitJson.filter(
+    (element): element is PcbTrace => element.type === "pcb_trace",
+  )
+  const pcbPorts = circuitJson.filter(
+    (element): element is PcbPort => element.type === "pcb_port",
+  )
+  const errors: PcbTraceError[] = []
+
+  for (const sourceTrace of sourceTraces) {
+    const maximumViaCount = sourceTrace.max_via_count
+    if (typeof maximumViaCount !== "number") continue
+
+    const routedPcbTraces = pcbTraces.filter(
+      (pcbTrace) => pcbTrace.source_trace_id === sourceTrace.source_trace_id,
+    )
+    if (routedPcbTraces.length === 0) continue
+
+    const actualViaCount = routedPcbTraces.reduce(
+      (viaCount, pcbTrace) =>
+        viaCount +
+        pcbTrace.route.filter((routePoint) => routePoint.route_type === "via")
+          .length,
+      0,
+    )
+    if (actualViaCount <= maximumViaCount) continue
+
+    const connectedPcbPorts = pcbPorts.filter(
+      (pcbPort) =>
+        pcbPort.source_port_id !== undefined &&
+        sourceTrace.connected_source_port_ids.includes(pcbPort.source_port_id),
+    )
+    errors.push({
+      type: "pcb_trace_error",
+      pcb_trace_error_id: `max_via_count_exceeded_${sourceTrace.source_trace_id}`,
+      error_type: "pcb_trace_error",
+      message: `PCB trace uses ${actualViaCount} vias, exceeding the ${maximumViaCount} maximum`,
+      pcb_trace_id: routedPcbTraces[0]!.pcb_trace_id,
+      source_trace_id: sourceTrace.source_trace_id,
+      pcb_component_ids: [
+        ...new Set(
+          connectedPcbPorts
+            .map((pcbPort) => pcbPort.pcb_component_id)
+            .filter(
+              (pcbComponentId): pcbComponentId is string =>
+                pcbComponentId !== undefined,
+            ),
+        ),
+      ],
+      pcb_port_ids: connectedPcbPorts.map((pcbPort) => pcbPort.pcb_port_id),
+      subcircuit_id:
+        routedPcbTraces[0]!.subcircuit_id ?? sourceTrace.subcircuit_id,
+    })
+  }
+
+  return errors
+}

--- a/lib/run-all-checks.ts
+++ b/lib/run-all-checks.ts
@@ -15,6 +15,7 @@ import { checkPcbComponentsOutOfBoard } from "./check-pcb-components-out-of-boar
 import { checkPcbComponentOverlap } from "./check-pcb-components-overlap/checkPcbComponentOverlap"
 import { checkPcbComponentsMissingCourtyard } from "./check-pcb-components-missing-courtyard"
 import { checkPcbTraceLengths } from "./check-pcb-trace-lengths"
+import { checkPcbTraceViaCounts } from "./check-pcb-trace-via-counts"
 import { checkPinMustBeConnected } from "./check-pin-must-be-connected"
 import { checkSameNetViaSpacing } from "./check-same-net-via-spacing"
 import { checkSchematicComponentExcessiveVerticalPadding } from "./check-schematic-component-excessive-vertical-padding"
@@ -64,6 +65,7 @@ export async function runAllRoutingChecks(circuitJson: AnyCircuitElement[]) {
     ...checkEachPcbPortConnectedToPcbTraces(circuitJson),
     ...checkSourceTracesHavePcbTraces(circuitJson),
     ...checkPcbTraceLengths(circuitJson),
+    ...checkPcbTraceViaCounts(circuitJson),
     ...checkEachPcbTraceNonOverlapping(circuitJson),
     ...checkPadTraceClearance(circuitJson),
     ...checkViaTraceClearance(circuitJson),

--- a/tests/lib/check-pcb-trace-via-counts.test.ts
+++ b/tests/lib/check-pcb-trace-via-counts.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, PcbTraceRoutePoint } from "circuit-json"
+import { checkPcbTraceViaCounts } from "lib/check-pcb-trace-via-counts"
+import { runAllRoutingChecks } from "lib/run-all-checks"
+
+const createTraceCircuitJson = (viaCount: number): AnyCircuitElement[] => [
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_xtal",
+    connected_source_port_ids: [],
+    connected_source_net_ids: [],
+    max_via_count: 0,
+  },
+  {
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_xtal",
+    source_trace_id: "source_trace_xtal",
+    route: [
+      { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
+      ...Array.from(
+        { length: viaCount },
+        (_, index): PcbTraceRoutePoint => ({
+          route_type: "via",
+          x: index + 1,
+          y: 0,
+          from_layer: index % 2 === 0 ? "top" : "bottom",
+          to_layer: index % 2 === 0 ? "bottom" : "top",
+        }),
+      ),
+      { route_type: "wire", x: viaCount + 1, y: 0, width: 0.15, layer: "top" },
+    ],
+  },
+]
+
+test("errors when a PCB trace exceeds max_via_count", async () => {
+  const circuitJson = createTraceCircuitJson(2)
+
+  expect(checkPcbTraceViaCounts(circuitJson)).toEqual([
+    expect.objectContaining({
+      type: "pcb_trace_error",
+      pcb_trace_error_id: "max_via_count_exceeded_source_trace_xtal",
+      source_trace_id: "source_trace_xtal",
+    }),
+  ])
+  expect(await runAllRoutingChecks(circuitJson)).toEqual(
+    expect.arrayContaining(checkPcbTraceViaCounts(circuitJson)),
+  )
+})
+
+test("accepts a PCB trace within max_via_count", () => {
+  expect(checkPcbTraceViaCounts(createTraceCircuitJson(0))).toEqual([])
+})


### PR DESCRIPTION
## Summary

- count routed vias for source traces that declare `max_via_count`
- emit a PCB trace error when the routed count exceeds the declared maximum
- run the validation alongside existing routing checks

## Tests

- `bun test tests/lib/check-pcb-trace-via-counts.test.ts`
- `bunx tsc --noEmit`
- `bun run build`