### PR TITLE
Treat missing component courtyards as placement errors

### DIFF
--- a/lib/check-pcb-components-missing-courtyard.ts
+++ b/lib/check-pcb-components-missing-courtyard.ts
@@ -1,7 +1,7 @@
 import type {
   AnyCircuitElement,
   PcbComponent,
-  PcbComponentMissingCourtyardWarning,
+  PcbPlacementError,
 } from "circuit-json"
 import { getReadableNameForComponent } from "./util/get-readable-names"
 
@@ -13,10 +13,10 @@ const courtyardTypes = new Set([
   "pcb_courtyard_rect",
 ])
 
-/** Returns a warning for every PCB component without a courtyard. */
+/** Returns a placement error for every PCB component without a courtyard. */
 export function checkPcbComponentsMissingCourtyard(
   circuitJson: AnyCircuitElement[],
-): PcbComponentMissingCourtyardWarning[] {
+): PcbPlacementError[] {
   const componentIdsWithCourtyards = new Set(
     circuitJson
       .filter((element) => courtyardTypes.has(element.type))
@@ -49,12 +49,10 @@ export function checkPcbComponentsMissingCourtyard(
           : getReadableNameForComponent(circuitJson, component.pcb_component_id)
 
       return {
-        type: "pcb_component_missing_courtyard_warning" as const,
-        pcb_component_missing_courtyard_warning_id: `pcb_component_missing_courtyard_warning_${component.pcb_component_id}`,
-        warning_type: "pcb_component_missing_courtyard_warning" as const,
+        type: "pcb_placement_error" as const,
+        pcb_placement_error_id: `missing_courtyard_${component.pcb_component_id}`,
+        error_type: "pcb_placement_error" as const,
         message: `${componentName} has no courtyard`,
-        pcb_component_id: component.pcb_component_id,
-        source_component_id: component.source_component_id,
         subcircuit_id: component.subcircuit_id,
       }
     })

--- a/tests/lib/check-pcb-components-missing-courtyard.test.ts
+++ b/tests/lib/check-pcb-components-missing-courtyard.test.ts
@@ -4,7 +4,7 @@ import { checkPcbComponentsMissingCourtyard } from "lib/check-pcb-components-mis
 import { containsCircuitJsonId } from "lib/util/get-readable-names"
 
 describe("checkPcbComponentsMissingCourtyard", () => {
-  test("returns a warning when a component has no courtyard", () => {
+  test("returns an error when a component has no courtyard", () => {
     const circuitJson = [
       {
         type: "source_component",
@@ -22,21 +22,20 @@ describe("checkPcbComponentsMissingCourtyard", () => {
       },
     ] as unknown as AnyCircuitElement[]
 
-    const warnings = checkPcbComponentsMissingCourtyard(circuitJson)
+    const errors = checkPcbComponentsMissingCourtyard(circuitJson)
 
-    expect(warnings).toEqual([
+    expect(errors).toEqual([
       expect.objectContaining({
-        type: "pcb_component_missing_courtyard_warning",
-        pcb_component_id: "pcb_component_1",
-        source_component_id: "source_component_1",
+        type: "pcb_placement_error",
+        error_type: "pcb_placement_error",
         message: "R1 has no courtyard",
       }),
     ])
-    expect(containsCircuitJsonId(warnings[0]!.message)).toBe(false)
-    expect(any_circuit_element.safeParse(warnings[0]).success).toBe(true)
+    expect(containsCircuitJsonId(errors[0]!.message)).toBe(false)
+    expect(any_circuit_element.safeParse(errors[0]).success).toBe(true)
   })
 
-  test("does not warn when a component has a courtyard", () => {
+  test("does not error when a component has a courtyard", () => {
     const circuitJson = [
       {
         type: "pcb_component",


### PR DESCRIPTION
## Summary

- upgrade the existing missing-courtyard diagnostic from a warning to a PCB placement error
- retain the existing exported check and placement-check integration
- update regression coverage for error behavior

## Tests

- `bun test tests/lib/check-pcb-components-missing-courtyard.test.ts`
- `bunx tsc --noEmit`
- `bun run build`