### PR TITLE
Validate pushbutton internal connection pairs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ export { checkPcbTracesOutOfBoard } from "./lib/check-trace-out-of-board/checkTr
 export { checkPcbComponentOverlap } from "./lib/check-pcb-components-overlap/checkPcbComponentOverlap"
 export { checkPcbComponentsMissingCourtyard } from "./lib/check-pcb-components-missing-courtyard"
 export { checkPcbTraceLengths } from "./lib/check-pcb-trace-lengths"
+export { checkPushButtonInternalConnections } from "./lib/check-push-button-internal-connections"
 export { checkPadPadClearance } from "./lib/check-pad-pad-clearance"
 export { checkPadTraceClearance } from "./lib/check-pad-trace-clearance"
 export { checkViaTraceClearance } from "./lib/check-via-trace-clearance"

--- a/lib/check-push-button-internal-connections.ts
+++ b/lib/check-push-button-internal-connections.ts
@@ -1,0 +1,69 @@
+import type {
+  AnyCircuitElement,
+  SourceComponentInternalConnection,
+  SourceComponentMisconfiguredError,
+  SourcePort,
+  SourceSimplePushButton,
+} from "circuit-json"
+
+/**
+ * Four-terminal pushbuttons require two declared internally-connected pin
+ * groups so netlist checks can validate the package topology.
+ */
+export const checkPushButtonInternalConnections = (
+  circuitJson: AnyCircuitElement[],
+): SourceComponentMisconfiguredError[] => {
+  const pushButtons = circuitJson.filter(
+    (element): element is SourceSimplePushButton =>
+      element.type === "source_component" &&
+      element.ftype === "simple_push_button",
+  )
+  const sourcePorts = circuitJson.filter(
+    (element): element is SourcePort => element.type === "source_port",
+  )
+  const internalConnections = circuitJson.filter(
+    (element): element is SourceComponentInternalConnection =>
+      element.type === "source_component_internal_connection",
+  )
+
+  const errors: SourceComponentMisconfiguredError[] = []
+
+  for (const pushButton of pushButtons) {
+    const pushButtonPorts = sourcePorts.filter(
+      (sourcePort) =>
+        sourcePort.source_component_id === pushButton.source_component_id,
+    )
+    if (pushButtonPorts.length <= 2) continue
+
+    const componentGroups =
+      pushButton.internally_connected_source_port_ids ?? []
+    const declaredGroups =
+      componentGroups.length > 0
+        ? componentGroups
+        : internalConnections
+            .filter(
+              (connection) =>
+                connection.source_component_id ===
+                pushButton.source_component_id,
+            )
+            .map((connection) => connection.source_port_ids)
+    const declaredPortIds = new Set(declaredGroups.flat())
+    const hasCompletePairTopology =
+      declaredGroups.length === 2 &&
+      declaredGroups.every((group) => group.length === 2) &&
+      pushButtonPorts.every((port) => declaredPortIds.has(port.source_port_id))
+
+    if (hasCompletePairTopology) continue
+
+    errors.push({
+      type: "source_component_misconfigured_error",
+      source_component_misconfigured_error_id: `push_button_internal_connections_${pushButton.source_component_id}`,
+      error_type: "source_component_misconfigured_error",
+      message: `Pushbutton ${pushButton.name} has ${pushButtonPorts.length} pins but does not declare two internally-connected pin pairs`,
+      source_component_ids: [pushButton.source_component_id],
+      source_port_ids: pushButtonPorts.map((port) => port.source_port_id),
+    })
+  }
+
+  return errors
+}

--- a/lib/run-all-checks.ts
+++ b/lib/run-all-checks.ts
@@ -16,6 +16,7 @@ import { checkPcbComponentOverlap } from "./check-pcb-components-overlap/checkPc
 import { checkPcbComponentsMissingCourtyard } from "./check-pcb-components-missing-courtyard"
 import { checkPcbTraceLengths } from "./check-pcb-trace-lengths"
 import { checkPinMustBeConnected } from "./check-pin-must-be-connected"
+import { checkPushButtonInternalConnections } from "./check-push-button-internal-connections"
 import { checkSameNetViaSpacing } from "./check-same-net-via-spacing"
 import { checkSchematicComponentExcessiveVerticalPadding } from "./check-schematic-component-excessive-vertical-padding"
 import { checkSourceTracesHavePcbTraces } from "./check-source-traces-have-pcb-traces"
@@ -42,7 +43,10 @@ export async function runAllPlacementChecks(circuitJson: AnyCircuitElement[]) {
 }
 
 export async function runAllNetlistChecks(circuitJson: AnyCircuitElement[]) {
-  return [...checkPinMustBeConnected(circuitJson)]
+  return [
+    ...checkPinMustBeConnected(circuitJson),
+    ...checkPushButtonInternalConnections(circuitJson),
+  ]
 }
 
 export async function runAllSchematicChecks(circuitJson: AnyCircuitElement[]) {

--- a/tests/lib/check-push-button-internal-connections.test.ts
+++ b/tests/lib/check-push-button-internal-connections.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { checkPushButtonInternalConnections } from "lib/check-push-button-internal-connections"
+import { runAllNetlistChecks } from "lib/run-all-checks"
+
+const createPushButtonCircuitJson = (
+  internallyConnectedSourcePortIds?: string[][],
+): AnyCircuitElement[] => [
+  {
+    type: "source_component",
+    source_component_id: "source_component_sw1",
+    name: "SW1",
+    ftype: "simple_push_button",
+    internally_connected_source_port_ids: internallyConnectedSourcePortIds,
+  },
+  ...[1, 2, 3, 4].map(
+    (pinNumber): AnyCircuitElement => ({
+      type: "source_port",
+      source_port_id: `source_port_sw1_${pinNumber}`,
+      source_component_id: "source_component_sw1",
+      name: `pin${pinNumber}`,
+      pin_number: pinNumber,
+      port_hints: [`pin${pinNumber}`],
+    }),
+  ),
+]
+
+test("errors when a four-pin pushbutton omits internal connection pairs", async () => {
+  const circuitJson = createPushButtonCircuitJson()
+
+  expect(checkPushButtonInternalConnections(circuitJson)).toEqual([
+    expect.objectContaining({
+      type: "source_component_misconfigured_error",
+      source_component_ids: ["source_component_sw1"],
+    }),
+  ])
+  expect(await runAllNetlistChecks(circuitJson)).toEqual(
+    expect.arrayContaining(checkPushButtonInternalConnections(circuitJson)),
+  )
+})
+
+test("accepts a four-pin pushbutton with two complete internal pairs", () => {
+  const circuitJson = createPushButtonCircuitJson([
+    ["source_port_sw1_1", "source_port_sw1_2"],
+    ["source_port_sw1_3", "source_port_sw1_4"],
+  ])
+
+  expect(checkPushButtonInternalConnections(circuitJson)).toEqual([])
+})


### PR DESCRIPTION
## Summary

- validate that multi-pin pushbuttons declare two complete internally connected pin pairs
- accept either component-level groups or source internal-connection records
- run the validation alongside existing netlist checks

## Tests

- `bun test tests/lib/check-push-button-internal-connections.test.ts`
- `bunx tsc --noEmit`
- `bun run build`