### PR TITLE
fix: reject disconnected via route transitions

### DIFF
--- a/lib/check-traces-are-contiguous/check-traces-are-contiguous.ts
+++ b/lib/check-traces-are-contiguous/check-traces-are-contiguous.ts
@@ -1,26 +1,70 @@
-import type {
-  AnyCircuitElement,
-  PcbTraceError,
-  PcbPort,
-  PcbTrace,
-  SourceTrace,
-  PcbSmtPad,
-  PcbPlatedHole,
-} from "circuit-json"
-import { isPointInPad } from "./is-point-in-pad"
-import { distance } from "../util/distance"
-import {
-  getPcbPortIdsConnectedToRoutePoint,
-  getPcbPortIdsConnectedToTrace,
-} from "../check-each-pcb-trace-non-overlapping/getPcbPortIdsConnectedToTraces"
 import {
   getReadableNameForPcbPort,
   getReadableNameForPcbTrace,
 } from "@tscircuit/circuit-json-util"
+import type {
+  AnyCircuitElement,
+  LayerRef,
+  PcbBoard,
+  PcbPlatedHole,
+  PcbPort,
+  PcbSmtPad,
+  PcbTrace,
+  PcbTraceError,
+  SourceTrace,
+} from "circuit-json"
 import { PcbConnectivityMap } from "circuit-json-to-connectivity-map"
+import {
+  getPcbPortIdsConnectedToRoutePoint,
+  getPcbPortIdsConnectedToTrace,
+} from "../check-each-pcb-trace-non-overlapping/getPcbPortIdsConnectedToTraces"
+import { distance } from "../util/distance"
+import { isPointInPad } from "./is-point-in-pad"
 
 type PcbPortId = PcbPort["pcb_port_id"]
 type PcbTraceRoutePoint = PcbTrace["route"][number]
+
+function getLayerIndex(
+  layer: LayerRef,
+  layerCount: number,
+): number | undefined {
+  if (layer === "top") return 0
+  if (layer === "bottom") return layerCount - 1
+
+  const innerLayerMatch = /^inner(\d+)$/.exec(layer)
+  if (!innerLayerMatch) return undefined
+
+  const layerIndex = Number(innerLayerMatch[1])
+  return layerIndex > 0 && layerIndex < layerCount - 1 ? layerIndex : undefined
+}
+
+function isLayerWithinViaSpan({
+  layer,
+  fromLayer,
+  toLayer,
+  layerCount,
+}: {
+  layer: LayerRef
+  fromLayer: LayerRef
+  toLayer: LayerRef
+  layerCount: number
+}): boolean {
+  const layerIndex = getLayerIndex(layer, layerCount)
+  const fromLayerIndex = getLayerIndex(fromLayer, layerCount)
+  const toLayerIndex = getLayerIndex(toLayer, layerCount)
+
+  if (
+    layerIndex === undefined ||
+    fromLayerIndex === undefined ||
+    toLayerIndex === undefined
+  ) {
+    return false
+  }
+
+  const spanStart = Math.min(fromLayerIndex, toLayerIndex)
+  const spanEnd = Math.max(fromLayerIndex, toLayerIndex)
+  return layerIndex >= spanStart && layerIndex <= spanEnd
+}
 
 function getRoutePointCenter(point: PcbTraceRoutePoint) {
   if (point.route_type === "through_pad") {
@@ -150,6 +194,12 @@ function checkTracesAreContiguous(
   const pcbPlatedHoles = circuitJson.filter(
     (el) => el.type === "pcb_plated_hole",
   ) as PcbPlatedHole[]
+  const pcbBoard = circuitJson.find((el) => el.type === "pcb_board") as
+    | PcbBoard
+    | undefined
+  // A board is present in complete Circuit JSON. Use the largest supported
+  // stack only for partial test fixtures that omit it.
+  const layerCount = pcbBoard?.num_layers ?? 10
 
   const padMap = new Map<PcbPortId, Array<PcbSmtPad | PcbPlatedHole>>()
   const pcbConnectivityMap = new PcbConnectivityMap(circuitJson)
@@ -186,51 +236,88 @@ function checkTracesAreContiguous(
         )
       : []
 
-    for (let i = 1; i < trace.route.length - 1; i++) {
+    const traceName = getReadableNameForPcbTrace(
+      circuitJson,
+      trace.pcb_trace_id,
+    )
+
+    for (let i = 0; i < trace.route.length; i++) {
       const prevPoint = trace.route[i - 1]
       const currentPoint = trace.route[i]
       const nextPoint = trace.route[i + 1]
 
       if (currentPoint.route_type === "via") {
-        const prevIsWire = prevPoint.route_type === "wire"
-        const nextIsWire = nextPoint.route_type === "wire"
+        if (
+          prevPoint?.route_type !== "wire" ||
+          nextPoint?.route_type !== "wire"
+        ) {
+          errors.push({
+            type: "pcb_trace_error",
+            message: `Via in trace [${traceName}] at position {x: ${currentPoint.x}, y: ${currentPoint.y}} must be immediately preceded and followed by wire route points.`,
+            source_trace_id:
+              sourceTrace?.source_trace_id ||
+              trace.source_trace_id ||
+              `!${trace.pcb_trace_id}`,
+            error_type: "pcb_trace_error",
+            pcb_trace_id: trace.pcb_trace_id,
+            pcb_trace_error_id: `unconnected_via_${trace.pcb_trace_id}_${i}`,
+            pcb_component_ids: [],
+            pcb_port_ids: [],
+          })
+          continue
+        }
 
-        if (prevIsWire && nextIsWire) {
-          const prevAligned =
-            Math.abs(prevPoint.x - currentPoint.x) < 0.01 &&
-            Math.abs(prevPoint.y - currentPoint.y) < 0.01
+        const prevAligned =
+          Math.abs(prevPoint.x - currentPoint.x) < 0.01 &&
+          Math.abs(prevPoint.y - currentPoint.y) < 0.01
 
-          const nextAligned =
-            Math.abs(nextPoint.x - currentPoint.x) < 0.01 &&
-            Math.abs(nextPoint.y - currentPoint.y) < 0.01
+        const nextAligned =
+          Math.abs(nextPoint.x - currentPoint.x) < 0.01 &&
+          Math.abs(nextPoint.y - currentPoint.y) < 0.01
 
-          if (!prevAligned || !nextAligned) {
-            const traceName = getReadableNameForPcbTrace(
-              circuitJson,
-              trace.pcb_trace_id,
-            )
-            errors.push({
-              type: "pcb_trace_error",
-              message: `Via in trace [${traceName}] is misaligned at position {x: ${currentPoint.x}, y: ${currentPoint.y}}.`,
-              source_trace_id:
-                sourceTrace?.source_trace_id ||
-                trace.source_trace_id ||
-                `!${trace.pcb_trace_id}`,
-              error_type: "pcb_trace_error",
-              pcb_trace_id: trace.pcb_trace_id,
-              pcb_trace_error_id: `misaligned_via_${trace.pcb_trace_id}_${i}`,
-              pcb_component_ids: [],
-              pcb_port_ids: [],
-            })
-          }
+        if (!prevAligned || !nextAligned) {
+          errors.push({
+            type: "pcb_trace_error",
+            message: `Via in trace [${traceName}] is misaligned at position {x: ${currentPoint.x}, y: ${currentPoint.y}}.`,
+            source_trace_id:
+              sourceTrace?.source_trace_id ||
+              trace.source_trace_id ||
+              `!${trace.pcb_trace_id}`,
+            error_type: "pcb_trace_error",
+            pcb_trace_id: trace.pcb_trace_id,
+            pcb_trace_error_id: `misaligned_via_${trace.pcb_trace_id}_${i}`,
+            pcb_component_ids: [],
+            pcb_port_ids: [],
+          })
+          continue
+        }
+
+        const layersMatch = [prevPoint.layer, nextPoint.layer].every((layer) =>
+          isLayerWithinViaSpan({
+            layer,
+            fromLayer: currentPoint.from_layer,
+            toLayer: currentPoint.to_layer,
+            layerCount,
+          }),
+        )
+
+        if (!layersMatch) {
+          errors.push({
+            type: "pcb_trace_error",
+            message: `Via in trace [${traceName}] spans ${currentPoint.from_layer} to ${currentPoint.to_layer}, but an adjacent wire layer (${prevPoint.layer}, ${nextPoint.layer}) is outside that physical span.`,
+            source_trace_id:
+              sourceTrace?.source_trace_id ||
+              trace.source_trace_id ||
+              `!${trace.pcb_trace_id}`,
+            error_type: "pcb_trace_error",
+            pcb_trace_id: trace.pcb_trace_id,
+            pcb_trace_error_id: `via_layer_mismatch_${trace.pcb_trace_id}_${i}`,
+            pcb_component_ids: [],
+            pcb_port_ids: [],
+          })
         }
       }
     }
-
-    const traceName = getReadableNameForPcbTrace(
-      circuitJson,
-      trace.pcb_trace_id,
-    )
 
     // Validate required ports once for the complete routed source trace.
     if (sourceTrace && expectedPorts.length > 0) {

--- a/tests/lib/check-traces-are-contiguous-via-transitions.test.ts
+++ b/tests/lib/check-traces-are-contiguous-via-transitions.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, PcbTrace } from "circuit-json"
+import { checkTracesAreContiguous } from "lib/check-traces-are-contiguous/check-traces-are-contiguous"
+
+const getViaTransitionErrorIds = (route: PcbTrace["route"]): string[] => {
+  const circuitJson = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_1",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      thickness: 1.6,
+      num_layers: 4,
+      material: "fr4",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_1",
+      source_trace_id: "source_trace_1",
+      route,
+    },
+  ] as AnyCircuitElement[]
+
+  return checkTracesAreContiguous(circuitJson)
+    .map((error) => error.pcb_trace_error_id)
+    .filter(
+      (errorId) =>
+        errorId.startsWith("unconnected_via_") ||
+        errorId.startsWith("misaligned_via_") ||
+        errorId.startsWith("via_layer_mismatch_"),
+    )
+}
+
+test("validates copper continuity around physical via spans", () => {
+  const reversedViaSpanRoute: PcbTrace["route"] = [
+    { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+    { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+    {
+      route_type: "via",
+      x: 1,
+      y: 0,
+      from_layer: "bottom",
+      to_layer: "top",
+    },
+    { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "bottom" },
+    { route_type: "wire", x: 2, y: 0, width: 0.2, layer: "bottom" },
+  ]
+
+  expect(getViaTransitionErrorIds(reversedViaSpanRoute)).toEqual([])
+
+  const innerLayerTapOnThroughViaRoute: PcbTrace["route"] = [
+    { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+    { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+    {
+      route_type: "via",
+      x: 1,
+      y: 0,
+      from_layer: "top",
+      to_layer: "bottom",
+    },
+    { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "inner1" },
+    { route_type: "wire", x: 2, y: 0, width: 0.2, layer: "inner1" },
+  ]
+
+  expect(getViaTransitionErrorIds(innerLayerTapOnThroughViaRoute)).toEqual([])
+
+  const consecutiveViaRoute: PcbTrace["route"] = [
+    { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+    { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+    {
+      route_type: "via",
+      x: 1,
+      y: 0,
+      from_layer: "top",
+      to_layer: "bottom",
+    },
+    {
+      route_type: "via",
+      x: 2,
+      y: 0,
+      from_layer: "bottom",
+      to_layer: "top",
+    },
+    { route_type: "wire", x: 2, y: 0, width: 0.2, layer: "top" },
+    { route_type: "wire", x: 3, y: 0, width: 0.2, layer: "top" },
+  ]
+
+  expect(getViaTransitionErrorIds(consecutiveViaRoute)).toEqual([
+    "unconnected_via_pcb_trace_1_2",
+    "unconnected_via_pcb_trace_1_3",
+  ])
+
+  const outsideViaSpanRoute: PcbTrace["route"] = [
+    { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+    { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+    {
+      route_type: "via",
+      x: 1,
+      y: 0,
+      from_layer: "inner1",
+      to_layer: "bottom",
+    },
+    { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "inner1" },
+    { route_type: "wire", x: 2, y: 0, width: 0.2, layer: "inner1" },
+  ]
+
+  expect(getViaTransitionErrorIds(outsideViaSpanRoute)).toEqual([
+    "via_layer_mismatch_pcb_trace_1_2",
+  ])
+})


### PR DESCRIPTION
## Summary

- require every `pcb_trace` via route point to be immediately bracketed by wire points
- keep the existing coordinate-alignment check and apply it to every valid via transition
- verify that adjacent wires lie within the via's inclusive physical layer span, including inner-layer taps on full-stack through vias

## Why

`checkTracesAreContiguous` previously inspected a via only when both neighboring route points were already wires. A malformed route such as `wire -> via -> via -> wire` therefore skipped validation entirely, even though no copper segment connects the two vias. The same blind spot allowed edge vias and layer-mismatched transitions through the shared routing checks.

This was reproduced while auditing the manufacturing output in `tscircuit/quick-configure`: an initially prepared USB-C fan-in path contained consecutive vias and would have exported without the intended bottom-layer copper.

The layer check treats `from_layer` / `to_layer` as the physical plated span. For example, a `top`-to-`bottom` via may legitimately connect adjacent `top` and `inner1` wire points.

## Validation

- `bun test` — 184 pass, 0 fail
- `bunx tsc --noEmit`
- `bun run build`
- focused regression coverage for valid reversed spans, inner-layer taps on through vias, consecutive vias, and wires outside a via's physical span
