### PR TITLE
fix: evaluate plated spans on intermediate layers

### DIFF
--- a/lib/check-different-net-via-spacing.ts
+++ b/lib/check-different-net-via-spacing.ts
@@ -1,4 +1,5 @@
 import { getReadableNameForElement } from "@tscircuit/circuit-json-util"
+import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 import type {
   AnyCircuitElement,
   PcbVia,
@@ -10,8 +11,8 @@ import {
 } from "circuit-json-to-connectivity-map"
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { distance } from "lib/util/distance"
+import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import { viasAreAtSameLocation } from "lib/util/viasAreAtSameLocation"
-import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 
 export function checkDifferentNetViaSpacing(
   circuitJson: AnyCircuitElement[],
@@ -23,6 +24,7 @@ export function checkDifferentNetViaSpacing(
   const vias = circuitJson.filter((el) => el.type === "pcb_via") as PcbVia[]
   if (vias.length < 2) return []
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   minClearance ??=
     getBoardDrcValue(board, "min_via_hole_edge_to_via_hole_edge_clearance") ??
     jlcMinTolerances.min_via_hole_edge_to_via_hole_edge_clearance
@@ -36,6 +38,12 @@ export function checkDifferentNetViaSpacing(
       const viaB = vias[j]
       // TODO: It is a very inefficient piece of code, the way to fix it is to use flatbush.
       if (viasAreAtSameLocation(viaA, viaB)) continue
+      if (
+        !getLayersOfPcbElement(viaA, layerCount).some((layer) =>
+          getLayersOfPcbElement(viaB, layerCount).includes(layer),
+        )
+      )
+        continue
       if (connMap.areIdsConnected(viaA.pcb_via_id, viaB.pcb_via_id)) continue
       const gap =
         distance(viaA, viaB) - viaA.hole_diameter / 2 - viaB.hole_diameter / 2

--- a/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
+++ b/lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping.ts
@@ -67,6 +67,7 @@ export function checkEachPcbTraceNonOverlapping(
   addStartAndEndPortIdsIfMissing(circuitJson)
   connMap ??= getFullConnectivityMapFromCircuitJson(circuitJson)
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   minClearance ??=
     getBoardDrcValue(board, "min_trace_to_pad_edge_clearance") ??
     DEFAULT_TRACE_MARGIN
@@ -173,7 +174,7 @@ export function checkEachPcbTraceNonOverlapping(
 
     for (const obj of nearbyObjects) {
       // ignore obstacles not on the trace's layer (except vias)
-      if (!getLayersOfPcbElement(obj).includes(segmentA.layer)) {
+      if (!getLayersOfPcbElement(obj, layerCount).includes(segmentA.layer)) {
         continue
       }
       if (

--- a/lib/check-pad-pad-clearance.ts
+++ b/lib/check-pad-pad-clearance.ts
@@ -2,12 +2,13 @@ import {
   getPrimaryId,
   getReadableNameForElement,
 } from "@tscircuit/circuit-json-util"
+import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 import type { AnyCircuitElement, PcbPadPadClearanceError } from "circuit-json"
-import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
+import { formatMm } from "format-si-unit"
 import { SpatialObjectIndex } from "lib/data-structures/SpatialIndex"
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
@@ -18,7 +19,6 @@ import {
   getPadToPadGap,
   getPads,
 } from "./check-pad-clearance/common"
-import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 
 export function checkPadPadClearance(
   circuitJson: AnyCircuitElement[],
@@ -31,6 +31,7 @@ export function checkPadPadClearance(
   if (pads.length < 2) return []
 
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   minClearance ??=
     getBoardDrcValue(board, "min_pad_edge_to_pad_edge_clearance") ??
     jlcMinTolerances.min_pad_edge_to_pad_edge_clearance
@@ -54,8 +55,8 @@ export function checkPadPadClearance(
       const padBId = getPrimaryId(padB)
       if (padAId === padBId) continue
       if (
-        !getLayersOfPcbElement(padA as any).some((layer) =>
-          getLayersOfPcbElement(padB as any).includes(layer),
+        !getLayersOfPcbElement(padA as any, layerCount).some((layer) =>
+          getLayersOfPcbElement(padB as any, layerCount).includes(layer),
         )
       ) {
         continue

--- a/lib/check-pad-trace-clearance.ts
+++ b/lib/check-pad-trace-clearance.ts
@@ -4,11 +4,11 @@ import {
 } from "@tscircuit/circuit-json-util"
 import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 import type { AnyCircuitElement, PcbPadTraceClearanceError } from "circuit-json"
-import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
+import { formatMm } from "format-si-unit"
 import { getCollidableBounds } from "lib/check-each-pcb-trace-non-overlapping/getCollidableBounds"
 import { SpatialObjectIndex } from "lib/data-structures/SpatialIndex"
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
@@ -35,6 +35,7 @@ export function checkPadTraceClearance(
   if (pads.length === 0 || segments.length === 0) return []
 
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   minClearance ??=
     getBoardDrcValue(board, "min_trace_to_pad_edge_clearance") ??
     jlcMinTolerances.min_trace_to_pad_edge_clearance
@@ -59,7 +60,10 @@ export function checkPadTraceClearance(
 
     for (const pad of nearbyPads) {
       const padId = getPrimaryId(pad)
-      if (!getLayersOfPcbElement(pad as any).includes(segment.layer)) continue
+      if (
+        !getLayersOfPcbElement(pad as any, layerCount).includes(segment.layer)
+      )
+        continue
       if (connMap.areIdsConnected(segment.pcb_trace_id, padId)) continue
       const pairId = `${padId}_${segment.pcb_trace_id}`
       const { gap } = getTraceObstacleClearance(segment, pad)

--- a/lib/check-same-net-via-spacing.ts
+++ b/lib/check-same-net-via-spacing.ts
@@ -1,4 +1,5 @@
 import { getReadableNameForElement } from "@tscircuit/circuit-json-util"
+import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 import type {
   AnyCircuitElement,
   PcbVia,
@@ -10,8 +11,8 @@ import {
 } from "circuit-json-to-connectivity-map"
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { distance } from "lib/util/distance"
+import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import { viasAreAtSameLocation } from "lib/util/viasAreAtSameLocation"
-import { jlcMinTolerances } from "@tscircuit/jlcpcb-manufacturing-specs"
 
 export function checkSameNetViaSpacing(
   circuitJson: AnyCircuitElement[],
@@ -23,6 +24,7 @@ export function checkSameNetViaSpacing(
   const vias = circuitJson.filter((el) => el.type === "pcb_via") as PcbVia[]
   if (vias.length < 2) return []
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   minClearance ??=
     getBoardDrcValue(board, "min_via_hole_edge_to_via_hole_edge_clearance") ??
     jlcMinTolerances.min_via_hole_edge_to_via_hole_edge_clearance
@@ -36,6 +38,12 @@ export function checkSameNetViaSpacing(
       const viaB = vias[j]
       // TODO: It is a very inefficient piece of code, the way to fix it is to use flatbush.
       if (viasAreAtSameLocation(viaA, viaB)) continue
+      if (
+        !getLayersOfPcbElement(viaA, layerCount).some((layer) =>
+          getLayersOfPcbElement(viaB, layerCount).includes(layer),
+        )
+      )
+        continue
       if (!connMap.areIdsConnected(viaA.pcb_via_id, viaB.pcb_via_id)) continue
       const gap =
         distance(viaA, viaB) - viaA.hole_diameter / 2 - viaB.hole_diameter / 2

--- a/lib/check-via-pad-clearance.ts
+++ b/lib/check-via-pad-clearance.ts
@@ -8,11 +8,11 @@ import type {
   PcbPadPadClearanceError,
   PcbVia,
 } from "circuit-json"
-import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
+import { formatMm } from "format-si-unit"
 import { SpatialObjectIndex } from "lib/data-structures/SpatialIndex"
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
@@ -38,6 +38,7 @@ export function checkViaPadClearance(
   if (vias.length === 0 || pads.length === 0) return []
 
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   const requiredClearance =
     minClearance ??
     getBoardDrcValue(board, "min_pad_edge_to_pad_edge_clearance") ??
@@ -60,8 +61,8 @@ export function checkViaPadClearance(
     for (const pad of nearbyPads) {
       const padId = getPrimaryId(pad)
       if (
-        !getLayersOfPcbElement(via).some((layer) =>
-          getLayersOfPcbElement(pad).includes(layer),
+        !getLayersOfPcbElement(via, layerCount).some((layer) =>
+          getLayersOfPcbElement(pad, layerCount).includes(layer),
         )
       ) {
         continue

--- a/lib/check-via-trace-clearance.ts
+++ b/lib/check-via-trace-clearance.ts
@@ -5,11 +5,11 @@ import type {
   PcbVia,
   PcbViaTraceClearanceError,
 } from "circuit-json"
-import { formatMm } from "format-si-unit"
 import {
   type ConnectivityMap,
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
+import { formatMm } from "format-si-unit"
 import { EPSILON, getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
 import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
 import {
@@ -31,6 +31,7 @@ export function checkViaTraceClearance(
   if (vias.length === 0 || segments.length === 0) return []
 
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   minClearance ??=
     getBoardDrcValue(board, "min_trace_to_pad_edge_clearance") ??
     jlcMinTolerances.min_trace_to_pad_edge_clearance
@@ -43,7 +44,8 @@ export function checkViaTraceClearance(
 
   for (const via of vias) {
     for (const segment of segments) {
-      if (!getLayersOfPcbElement(via).includes(segment.layer)) continue
+      if (!getLayersOfPcbElement(via, layerCount).includes(segment.layer))
+        continue
       if (connMap.areIdsConnected(segment.pcb_trace_id, via.pcb_via_id))
         continue
 

--- a/lib/check-vias-in-pads.ts
+++ b/lib/check-vias-in-pads.ts
@@ -8,13 +8,14 @@ import {
 import { isPointInPad } from "./check-traces-are-contiguous/is-point-in-pad"
 import { SpatialObjectIndex } from "./data-structures/SpatialIndex"
 import { getPcbBoard } from "./drc-defaults"
-import { getLayersOfPcbElement } from "./util/getLayersOfPcbElement"
 import { getReadableNameForFootprintPad } from "./util/get-readable-names"
+import { getLayersOfPcbElement } from "./util/getLayersOfPcbElement"
 
 export function checkViasInPads(
   circuitJson: AnyCircuitElement[],
 ): PcbPlacementError[] {
   const board = getPcbBoard(circuitJson)
+  const layerCount = board?.num_layers
   if (
     board &&
     "is_via_in_pad_allowed" in board &&
@@ -48,8 +49,8 @@ export function checkViasInPads(
     })
 
     for (const pad of nearbyPads) {
-      const viaLayers = getLayersOfPcbElement(via)
-      const padLayers = getLayersOfPcbElement(pad)
+      const viaLayers = getLayersOfPcbElement(via, layerCount)
+      const padLayers = getLayersOfPcbElement(pad, layerCount)
       if (!viaLayers.some((layer) => padLayers.includes(layer))) continue
       if (!isPointInPad(via, pad)) continue
 

--- a/lib/util/getLayersOfPcbElement.ts
+++ b/lib/util/getLayersOfPcbElement.ts
@@ -1,7 +1,52 @@
-import type { Collidable } from "lib/check-each-pcb-trace-non-overlapping/getCollidableBounds"
 import { all_layers } from "circuit-json"
+import type { Collidable } from "lib/check-each-pcb-trace-non-overlapping/getCollidableBounds"
 
-export function getLayersOfPcbElement(obj: Collidable): string[] {
+const getPhysicalLayerStack = (layerCount?: number): string[] => {
+  if (layerCount === 1) return ["top"]
+  if (layerCount !== undefined && layerCount >= 2) {
+    return [
+      "top",
+      ...Array.from(
+        { length: Math.max(0, layerCount - 2) },
+        (_, index) => `inner${index + 1}`,
+      ),
+      "bottom",
+    ]
+  }
+
+  return [
+    "top",
+    ...all_layers
+      .filter((layer) => /^inner[1-9][0-9]*$/.test(layer))
+      .sort(
+        (a, b) =>
+          Number(a.slice("inner".length)) - Number(b.slice("inner".length)),
+      ),
+    "bottom",
+  ]
+}
+
+const expandPlatedLayerSpan = (
+  layers: string[],
+  layerCount?: number,
+): string[] => {
+  if (layers.length !== 2) return layers
+
+  const stack = getPhysicalLayerStack(layerCount)
+  const firstIndex = stack.indexOf(layers[0]!)
+  const secondIndex = stack.indexOf(layers[1]!)
+  if (firstIndex === -1 || secondIndex === -1) return layers
+
+  return stack.slice(
+    Math.min(firstIndex, secondIndex),
+    Math.max(firstIndex, secondIndex) + 1,
+  )
+}
+
+export function getLayersOfPcbElement(
+  obj: Collidable,
+  layerCount?: number,
+): string[] {
   if (obj.type === "pcb_trace_segment") {
     return [obj.layer]
   }
@@ -9,13 +54,17 @@ export function getLayersOfPcbElement(obj: Collidable): string[] {
     return [obj.layer]
   }
   if (obj.type === "pcb_plated_hole") {
-    return Array.isArray(obj.layers) ? obj.layers : [...all_layers]
+    return Array.isArray(obj.layers)
+      ? expandPlatedLayerSpan(obj.layers, layerCount)
+      : [...all_layers]
   }
   if (obj.type === "pcb_hole") {
     return [...all_layers]
   }
   if (obj.type === "pcb_via") {
-    return Array.isArray(obj.layers) ? obj.layers : [...all_layers]
+    return Array.isArray(obj.layers)
+      ? expandPlatedLayerSpan(obj.layers, layerCount)
+      : [...all_layers]
   }
   if (obj.type === "pcb_keepout") {
     return Array.isArray(obj.layers) ? obj.layers : []

--- a/tests/lib/check-disjoint-via-span-spacing.test.ts
+++ b/tests/lib/check-disjoint-via-span-spacing.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { checkDifferentNetViaSpacing } from "lib/check-different-net-via-spacing"
+import { checkSameNetViaSpacing } from "lib/check-same-net-via-spacing"
+
+test("nearby vias on disjoint physical spans do not require spacing", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      thickness: 1.6,
+      num_layers: 6,
+      material: "fr4",
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "upper_via",
+      x: 0,
+      y: 0,
+      hole_diameter: 0.3,
+      outer_diameter: 0.5,
+      layers: ["top", "inner1"],
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "lower_via",
+      x: 0.1,
+      y: 0,
+      hole_diameter: 0.3,
+      outer_diameter: 0.5,
+      layers: ["inner2", "bottom"],
+    },
+  ]
+
+  expect(
+    checkDifferentNetViaSpacing(circuitJson, {
+      connMap: { areIdsConnected: () => false } as any,
+    }),
+  ).toEqual([])
+  expect(
+    checkSameNetViaSpacing(circuitJson, {
+      connMap: { areIdsConnected: () => true } as any,
+    }),
+  ).toEqual([])
+})

--- a/tests/lib/check-via-intermediate-layer-clearance.test.ts
+++ b/tests/lib/check-via-intermediate-layer-clearance.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { checkEachPcbTraceNonOverlapping } from "lib/check-each-pcb-trace-non-overlapping/check-each-pcb-trace-non-overlapping"
+import { checkViaTraceClearance } from "lib/check-via-trace-clearance"
+
+test("a through via conflicts with unrelated copper on an intermediate layer", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      thickness: 1.6,
+      num_layers: 4,
+      material: "fr4",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "inner_trace",
+      route: [
+        {
+          route_type: "wire",
+          x: -1,
+          y: 0,
+          width: 0.15,
+          layer: "inner2",
+        },
+        {
+          route_type: "wire",
+          x: 1,
+          y: 0,
+          width: 0.15,
+          layer: "inner2",
+        },
+      ],
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "through_via",
+      pcb_trace_id: "via_trace",
+      x: 0,
+      y: 0,
+      hole_diameter: 0.25,
+      outer_diameter: 0.5,
+      layers: ["top", "bottom"],
+    },
+  ]
+  const connMap = {
+    areIdsConnected: (a: string, b: string) => a === b,
+  } as any
+
+  expect(checkViaTraceClearance(circuitJson, { connMap })).toEqual([])
+  expect(
+    checkEachPcbTraceNonOverlapping(circuitJson, { connMap }),
+  ).toContainEqual(
+    expect.objectContaining({
+      type: "pcb_trace_error",
+      pcb_trace_id: "inner_trace",
+    }),
+  )
+})

--- a/tests/lib/check-via-intermediate-layer-pad-clearance.test.ts
+++ b/tests/lib/check-via-intermediate-layer-pad-clearance.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { checkViaPadClearance } from "lib/check-via-pad-clearance"
+
+test("a through via conflicts with an unrelated pad on an intermediate layer", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      thickness: 1.6,
+      num_layers: 4,
+      material: "fr4",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "inner_pad",
+      shape: "circle",
+      x: 0,
+      y: 0,
+      radius: 0.25,
+      layer: "inner2",
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "through_via",
+      pcb_trace_id: "through_trace",
+      x: 0,
+      y: 0,
+      hole_diameter: 0.25,
+      outer_diameter: 0.5,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "blind_via",
+      pcb_trace_id: "blind_trace",
+      x: 0,
+      y: 0,
+      hole_diameter: 0.25,
+      outer_diameter: 0.5,
+      layers: ["top", "inner1"],
+    },
+  ]
+
+  const errors = checkViaPadClearance(circuitJson, {
+    connMap: {
+      areIdsConnected: (a: string, b: string) => a === b,
+    } as any,
+  })
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0]?.pcb_pad_ids).toEqual(["through_via", "inner_pad"])
+})

--- a/tests/lib/check-via-intermediate-layer-positive-clearance.test.ts
+++ b/tests/lib/check-via-intermediate-layer-positive-clearance.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { checkViaTraceClearance } from "lib/check-via-trace-clearance"
+
+test("a through via requires clearance from an intermediate-layer trace", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board",
+      center: { x: 0, y: 0 },
+      width: 10,
+      height: 10,
+      thickness: 1.6,
+      num_layers: 4,
+      material: "fr4",
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "inner_trace",
+      route: [
+        {
+          route_type: "wire",
+          x: -1,
+          y: 0,
+          width: 0.1,
+          layer: "inner2",
+        },
+        {
+          route_type: "wire",
+          x: 1,
+          y: 0,
+          width: 0.1,
+          layer: "inner2",
+        },
+      ],
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "through_via",
+      pcb_trace_id: "via_trace",
+      x: 0,
+      y: 0.3,
+      hole_diameter: 0.25,
+      outer_diameter: 0.4,
+      layers: ["top", "bottom"],
+    },
+  ]
+
+  const errors = checkViaTraceClearance(circuitJson, {
+    connMap: { areIdsConnected: () => false } as any,
+  })
+
+  expect(errors).toHaveLength(1)
+  expect(errors[0]).toMatchObject({
+    pcb_via_id: "through_via",
+    pcb_trace_id: "inner_trace",
+  })
+  expect(errors[0]!.actual_clearance).toBeCloseTo(0.05)
+})

--- a/tests/lib/get-layers-of-pcb-element.test.ts
+++ b/tests/lib/get-layers-of-pcb-element.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { getLayersOfPcbElement } from "lib/util/getLayersOfPcbElement"
+
+test("plated spans include every physical layer between their endpoints", () => {
+  const throughVia = {
+    type: "pcb_via",
+    layers: ["top", "bottom"],
+  } as any
+  const reversedThroughVia = {
+    type: "pcb_via",
+    layers: ["bottom", "top"],
+  } as any
+  const blindVia = {
+    type: "pcb_via",
+    layers: ["top", "inner1"],
+  } as any
+  const buriedVia = {
+    type: "pcb_via",
+    layers: ["inner1", "inner2"],
+  } as any
+  const throughHole = {
+    type: "pcb_plated_hole",
+    layers: ["top", "bottom"],
+  } as any
+
+  expect(getLayersOfPcbElement(throughVia, 4)).toEqual([
+    "top",
+    "inner1",
+    "inner2",
+    "bottom",
+  ])
+  expect(getLayersOfPcbElement(reversedThroughVia, 4)).toEqual([
+    "top",
+    "inner1",
+    "inner2",
+    "bottom",
+  ])
+  expect(getLayersOfPcbElement(blindVia, 4)).toEqual(["top", "inner1"])
+  expect(getLayersOfPcbElement(buriedVia, 4)).toEqual(["inner1", "inner2"])
+  expect(getLayersOfPcbElement(throughHole, 4)).toEqual([
+    "top",
+    "inner1",
+    "inner2",
+    "bottom",
+  ])
+  expect(getLayersOfPcbElement(throughVia)).toContain("inner8")
+})


### PR DESCRIPTION
## Summary

- expand via and plated-hole endpoint pairs to every physical board layer in their inclusive span
- use the board's `num_layers` when evaluating trace overlap/clearance, pad clearance, via-in-pad, and via-spacing checks
- handle reversed endpoint order and retain blind/buried partial spans
- apply via-spacing rules only when the two physical plated spans overlap

## Why

Circuit JSON stores a plated via span by its endpoint layers. On a four-layer board, `layers: ["top", "bottom"]` is physically present on `top`, `inner1`, `inner2`, and `bottom`. The shared layer helper previously returned only the two literal array entries, so routing checks could miss an unrelated trace or pad on an intermediate layer.

Conversely, two nearby blind or buried vias with disjoint physical spans do not need layer-to-layer clearance from each other. The spacing checks now use the same board-aware span interpretation to avoid that false positive.

This is the final Circuit JSON safety-net companion to tscircuit/high-density-repair03#79 and the through-via work for [tscircuit/tscircuit-autorouter#2156](https://github.com/tscircuit/tscircuit-autorouter/issues/2156). The router-side DRC prevents bad output while routing; this PR ensures ordinary post-render checks interpret the same physical span correctly.

## Validation

- `bun test` — 188 pass, 0 fail
- focused coverage for four-layer forward/reversed/partial spans, intermediate-layer trace overlap and positive clearance, intermediate-layer pad clearance, and disjoint blind/buried via spacing
- `bunx tsc --noEmit`
- `bun run build`
- Biome check and `git diff --check`
