### PR TITLE
Fix detection of unrouted port-to-net connections

### DIFF
--- a/lib/check-each-pcb-port-connected-to-pcb-trace.ts
+++ b/lib/check-each-pcb-port-connected-to-pcb-trace.ts
@@ -3,9 +3,13 @@ import type {
   SourceTrace,
   AnyCircuitElement,
   PcbPortNotConnectedError,
+  SourceNet,
 } from "circuit-json"
 import { addStartAndEndPortIdsIfMissing } from "./add-start-and-end-port-ids-if-missing"
-import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
+import {
+  getFullConnectivityMapFromCircuitJson,
+  PcbConnectivityMap,
+} from "circuit-json-to-connectivity-map"
 import { getReadableNameForPort } from "./util/get-readable-names"
 
 function checkEachPcbPortConnectedToPcbTraces(
@@ -19,11 +23,15 @@ function checkEachPcbPortConnectedToPcbTraces(
   const pcbPorts: PcbPort[] = circuitJson.filter(
     (item) => item.type === "pcb_port",
   ) as PcbPort[]
+  const sourceNets: SourceNet[] = circuitJson.filter(
+    (item) => item.type === "source_net",
+  ) as SourceNet[]
 
   const errors: PcbPortNotConnectedError[] = []
 
   // Generate the connectivity map from the circuit
   const connectivityMap = getFullConnectivityMapFromCircuitJson(circuitJson)
+  const pcbConnectivityMap = new PcbConnectivityMap(circuitJson)
 
   // Create a map from source_port_id to pcb_port for quick lookup
   const sourcePortToPcbPort = new Map<string, PcbPort>()
@@ -31,9 +39,48 @@ function checkEachPcbPortConnectedToPcbTraces(
     sourcePortToPcbPort.set(pcbPort.source_port_id, pcbPort)
   }
 
+  const sourceNetNameById = new Map(
+    sourceNets.map((sourceNet) => [sourceNet.source_net_id, sourceNet.name]),
+  )
+
   // Process each source trace
   for (const sourceTrace of sourceTraces) {
     const connectedSourcePortIds = sourceTrace.connected_source_port_ids
+
+    if (
+      connectedSourcePortIds.length === 1 &&
+      sourceTrace.connected_source_net_ids.length > 0
+    ) {
+      const pcbPort = sourcePortToPcbPort.get(connectedSourcePortIds[0])
+      if (!pcbPort) continue
+
+      const connectedPcbTraces = pcbConnectivityMap.getAllTracesConnectedToPort(
+        pcbPort.pcb_port_id,
+      )
+
+      if (connectedPcbTraces.length === 0) {
+        const connectedNetNames = sourceTrace.connected_source_net_ids
+          .map((sourceNetId) => sourceNetNameById.get(sourceNetId))
+          .filter((name): name is string => Boolean(name))
+        const netDescription =
+          connectedNetNames.length > 0
+            ? `net [${connectedNetNames.join(", ")}]`
+            : "its connected net"
+
+        errors.push({
+          type: "pcb_port_not_connected_error",
+          message: `Port [${getReadableNameForPort(circuitJson, pcbPort.pcb_port_id)}] is not connected to ${netDescription} by a PCB trace.`,
+          error_type: "pcb_port_not_connected_error",
+          pcb_port_ids: [pcbPort.pcb_port_id],
+          pcb_component_ids: pcbPort.pcb_component_id
+            ? [pcbPort.pcb_component_id]
+            : [],
+          pcb_port_not_connected_error_id: `pcb_port_not_connected_error_trace_${sourceTrace.source_trace_id}`,
+        })
+      }
+
+      continue
+    }
 
     // Skip traces with less than 2 ports (nothing to connect)
     if (connectedSourcePortIds.length < 2) {

--- a/tests/lib/check-each-pcb-port-connected.test.ts
+++ b/tests/lib/check-each-pcb-port-connected.test.ts
@@ -197,6 +197,98 @@ describe("checkEachPcbPortConnectedToPcbTraces", () => {
     expect(containsCircuitJsonId(errors[0]!.message)).toBe(false)
   })
 
+  test("returns an error for an unrouted port-to-net trace", () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "source_component",
+        source_component_id: "source_component_r_fault_pu",
+        ftype: "simple_resistor",
+        name: "R_FAULT_PU",
+        resistance: 10_000,
+        supplier_part_numbers: {},
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_r_fault_pu_2",
+        source_component_id: "source_component_r_fault_pu",
+        name: "pin2",
+        pin_number: 2,
+        port_hints: ["2"],
+      },
+      {
+        type: "source_net",
+        source_net_id: "source_net_v3v3",
+        name: "V3V3",
+        member_source_group_ids: [],
+        is_power: true,
+      },
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_fault_pullup_3v3",
+        connected_source_port_ids: ["source_port_r_fault_pu_2"],
+        connected_source_net_ids: ["source_net_v3v3"],
+      },
+      {
+        type: "pcb_component",
+        source_component_id: "source_component_r_fault_pu",
+        pcb_component_id: "pcb_component_r_fault_pu",
+        width: 1.56,
+        height: 0.64,
+        rotation: 0,
+        layer: "top",
+        center: { x: 18, y: -4.5 },
+        obstructs_within_bounds: true,
+      },
+      {
+        type: "pcb_port",
+        pcb_port_id: "pcb_port_r_fault_pu_2",
+        source_port_id: "source_port_r_fault_pu_2",
+        pcb_component_id: "pcb_component_r_fault_pu",
+        x: 18.51,
+        y: -4.5,
+        layers: ["top"],
+      },
+    ]
+
+    expect(checkEachPcbPortConnectedToPcbTraces(circuitJson)).toEqual([
+      {
+        type: "pcb_port_not_connected_error",
+        message:
+          "Port [R_FAULT_PU.pin2] is not connected to net [V3V3] by a PCB trace.",
+        error_type: "pcb_port_not_connected_error",
+        pcb_port_ids: ["pcb_port_r_fault_pu_2"],
+        pcb_component_ids: ["pcb_component_r_fault_pu"],
+        pcb_port_not_connected_error_id:
+          "pcb_port_not_connected_error_trace_source_trace_fault_pullup_3v3",
+      },
+    ])
+
+    circuitJson.push({
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_fault_pullup_3v3",
+      source_trace_id: "source_trace_fault_pullup_3v3",
+      route: [
+        {
+          route_type: "wire",
+          x: 18.51,
+          y: -4.5,
+          width: 0.15,
+          layer: "top",
+          start_pcb_port_id: "pcb_port_r_fault_pu_2",
+        },
+        {
+          route_type: "wire",
+          x: 20,
+          y: -4.5,
+          width: 0.15,
+          layer: "top",
+        },
+      ],
+    })
+
+    expect(checkEachPcbPortConnectedToPcbTraces(circuitJson)).toEqual([])
+  })
+
   test("should prefer source component and source port names in errors", () => {
     const circuitJson: AnyCircuitElement[] = [
       {


### PR DESCRIPTION
## Summary
- detect single component ports that are logically connected to a named net but have no physical PCB trace
- use the PCB connectivity map after annotating trace endpoints
- add a regression covering the R_FAULT_PU pin2 to V3V3 failure and its routed success case

## Root cause
The PCB port connectivity check skipped source traces with fewer than two component ports. Port-to-net traces contain one component port, so an unrouted pad was ignored even though the logical netlist was valid.

## Validation
- bun test: 184 passed, 0 failed
- bun run build: passed
- checked the RP2040 motor-controller Circuit JSON: reports exactly R_FAULT_PU.pin2 as disconnected from V3V3