### PR TITLE
Speed up placement checks for detailed board outlines

### DIFF
--- a/lib/check-copper-to-board-edge-clearance.ts
+++ b/lib/check-copper-to-board-edge-clearance.ts
@@ -11,6 +11,13 @@ import type {
   PcbVia,
 } from "circuit-json"
 import { getBoardDrcValue, getPcbBoard } from "lib/drc-defaults"
+import {
+  arePointsInsideBoard,
+  createBoardEdgeSpatialIndex,
+  getBoardEdgesNearBox,
+  type BoardEdgeSpatialIndex,
+  type BoardOutlinePoint,
+} from "lib/utils/geometry/create-board-edge-spatial-index"
 import { applyToPoint, rotateDEG } from "transformation-matrix"
 
 type CopperElement = PcbVia | PcbSmtPad | PcbPlatedHole | PcbCopperPour
@@ -99,9 +106,9 @@ const brepRingToPolygon = (
   return polygon
 }
 
-const boardToPolygon = (board: PcbBoard): Flatten.Polygon | null => {
+const boardToOutline = (board: PcbBoard): BoardOutlinePoint[] | null => {
   if (board.outline && board.outline.length >= 3) {
-    return pointsToPolygon(board.outline)
+    return board.outline
   }
 
   if (
@@ -114,12 +121,12 @@ const boardToPolygon = (board: PcbBoard): Flatten.Polygon | null => {
 
   const halfWidth = board.width / 2
   const halfHeight = board.height / 2
-  return pointsToPolygon([
+  return [
     { x: board.center.x - halfWidth, y: board.center.y - halfHeight },
     { x: board.center.x + halfWidth, y: board.center.y - halfHeight },
     { x: board.center.x + halfWidth, y: board.center.y + halfHeight },
     { x: board.center.x - halfWidth, y: board.center.y + halfHeight },
-  ])
+  ]
 }
 
 const getRectanglePolygon = ({
@@ -438,29 +445,111 @@ const getCopperElementLabel = (element: CopperElement): string => {
   return "Copper pour"
 }
 
-const measureClearance = (
-  board: Flatten.Polygon,
-  geometry: CopperGeometry,
-): { isInside: boolean; clearance: number } => {
-  if (geometry.kind === "shapes") {
-    const isInside = geometry.shapes.every((shape) => board.contains(shape))
-    return {
-      isInside,
-      clearance: isInside
-        ? Math.min(
-            ...geometry.shapes.map((shape) => board.distanceTo(shape)[0]),
-          )
-        : 0,
+const measureShapeClearance = ({
+  shape,
+  requiredClearance,
+  boardEdgeSpatialIndex,
+}: {
+  shape: CopperShape
+  requiredClearance: number
+  boardEdgeSpatialIndex: BoardEdgeSpatialIndex
+}): { isInside: boolean; clearance: number } => {
+  const nearbyBoardEdges = getBoardEdgesNearBox({
+    box: shape.box,
+    margin: requiredClearance,
+    boardEdgeSpatialIndex,
+  })
+  if (nearbyBoardEdges.length === 0) {
+    let points: BoardOutlinePoint[]
+    if (shape instanceof Flatten.Circle) {
+      points = [shape.center]
+    } else {
+      points = shape.vertices
     }
+    const isInside = arePointsInsideBoard({
+      points,
+      boardEdgeSpatialIndex,
+    })
+    if (!isInside) return { isInside: false, clearance: 0 }
+    return { isInside: true, clearance: Number.POSITIVE_INFINITY }
   }
 
-  const centerLineClearance = board.distanceTo(geometry.centerLine)[0]
+  const isInside = boardEdgeSpatialIndex.boardPolygon.contains(shape)
+  if (!isInside) return { isInside: false, clearance: 0 }
+
+  const clearance = Math.min(
+    ...nearbyBoardEdges.map((boardEdge) => boardEdge.distanceTo(shape)[0]),
+  )
+  return { isInside: true, clearance }
+}
+
+const measurePillClearance = ({
+  geometry,
+  requiredClearance,
+  boardEdgeSpatialIndex,
+}: {
+  geometry: Extract<CopperGeometry, { kind: "pill" }>
+  requiredClearance: number
+  boardEdgeSpatialIndex: BoardEdgeSpatialIndex
+}): { isInside: boolean; clearance: number } => {
+  const nearbyBoardEdges = getBoardEdgesNearBox({
+    box: geometry.centerLine.box,
+    margin: geometry.radius + requiredClearance,
+    boardEdgeSpatialIndex,
+  })
+  if (nearbyBoardEdges.length === 0) {
+    const isInside = arePointsInsideBoard({
+      points: geometry.centerLine.vertices,
+      boardEdgeSpatialIndex,
+    })
+    if (!isInside) return { isInside: false, clearance: 0 }
+    return { isInside: true, clearance: Number.POSITIVE_INFINITY }
+  }
+
+  const centerLineClearance = Math.min(
+    ...nearbyBoardEdges.map(
+      (boardEdge) => boardEdge.distanceTo(geometry.centerLine)[0],
+    ),
+  )
   const clearance = centerLineClearance - geometry.radius
   const isInside =
-    board.contains(geometry.centerLine) && clearance >= -GEOMETRY_EPSILON
+    boardEdgeSpatialIndex.boardPolygon.contains(geometry.centerLine) &&
+    clearance >= -GEOMETRY_EPSILON
+  if (!isInside) return { isInside: false, clearance: 0 }
+  return { isInside: true, clearance: Math.max(0, clearance) }
+}
+
+const measureClearance = ({
+  geometry,
+  requiredClearance,
+  boardEdgeSpatialIndex,
+}: {
+  geometry: CopperGeometry
+  requiredClearance: number
+  boardEdgeSpatialIndex: BoardEdgeSpatialIndex
+}): { isInside: boolean; clearance: number } => {
+  if (geometry.kind === "pill") {
+    return measurePillClearance({
+      geometry,
+      requiredClearance,
+      boardEdgeSpatialIndex,
+    })
+  }
+
+  const measurements = geometry.shapes.map((shape) =>
+    measureShapeClearance({
+      shape,
+      requiredClearance,
+      boardEdgeSpatialIndex,
+    }),
+  )
+  const isInside = measurements.every((measurement) => measurement.isInside)
+  if (!isInside) return { isInside: false, clearance: 0 }
   return {
-    isInside,
-    clearance: isInside ? Math.max(0, clearance) : 0,
+    isInside: true,
+    clearance: Math.min(
+      ...measurements.map((measurement) => measurement.clearance),
+    ),
   }
 }
 
@@ -480,13 +569,14 @@ export function checkCopperToBoardEdgeClearance(
   const board = getPcbBoard(circuitJson)
   if (!board) return []
 
-  const boardPolygon = boardToPolygon(board)
-  if (!boardPolygon) return []
+  const boardOutline = boardToOutline(board)
+  if (!boardOutline) return []
 
   const requiredClearance =
     getBoardDrcValue(board, "min_board_edge_clearance") ??
     jlcMinTolerances.min_board_edge_clearance
   if (requiredClearance === undefined) return []
+  const boardEdgeSpatialIndex = createBoardEdgeSpatialIndex(boardOutline)
 
   const copperElements = circuitJson.filter(
     (element): element is CopperElement =>
@@ -511,7 +601,11 @@ export function checkCopperToBoardEdgeClearance(
     const geometry = getCopperGeometry(element, componentCcwRotationsById)
     if (!geometry) continue
 
-    const { isInside, clearance } = measureClearance(boardPolygon, geometry)
+    const { isInside, clearance } = measureClearance({
+      geometry,
+      requiredClearance,
+      boardEdgeSpatialIndex,
+    })
     if (isInside && clearance + GEOMETRY_EPSILON >= requiredClearance) {
       continue
     }

--- a/lib/check-pcb-components-out-of-board/checkPcbComponentsOutOfBoard.ts
+++ b/lib/check-pcb-components-out-of-board/checkPcbComponentsOutOfBoard.ts
@@ -8,6 +8,12 @@ import type {
 import { getReadableNameForComponent } from "lib/util/get-readable-names"
 import type { Point } from "@tscircuit/math-utils"
 import * as Flatten from "@flatten-js/core"
+import {
+  arePointsInsideBoard,
+  createBoardEdgeSpatialIndex,
+  getBoardEdgesNearBox,
+  type BoardEdgeSpatialIndex,
+} from "lib/utils/geometry/create-board-edge-spatial-index"
 import { rotateDEG, applyToPoint } from "transformation-matrix"
 
 /**
@@ -264,6 +270,27 @@ function getRepositionSuggestion({
   return `Try moving it ${absDy}mm ${yDir} to fit within the board edge.`
 }
 
+const isComponentInsideBoard = ({
+  componentPolygon,
+  boardEdgeSpatialIndex,
+}: {
+  componentPolygon: Flatten.Polygon
+  boardEdgeSpatialIndex: BoardEdgeSpatialIndex
+}): boolean => {
+  const nearbyBoardEdges = getBoardEdgesNearBox({
+    box: componentPolygon.box,
+    margin: 0,
+    boardEdgeSpatialIndex,
+  })
+  if (nearbyBoardEdges.length > 0) {
+    return boardEdgeSpatialIndex.boardPolygon.contains(componentPolygon)
+  }
+  return arePointsInsideBoard({
+    points: componentPolygon.vertices,
+    boardEdgeSpatialIndex,
+  })
+}
+
 /**
  * Main function — polygon-first: construct polygons, test containment / intersection,
  * compute overlap distance using boolean intersection area or geometric distance.
@@ -278,6 +305,7 @@ export function checkPcbComponentsOutOfBoard(
 
   const boardPoly = boardToPolygon({ board })
   if (!boardPoly) return []
+  const boardEdgeSpatialIndex = createBoardEdgeSpatialIndex(boardPoly.vertices)
 
   const components = circuitJson.filter(
     (el): el is PcbComponent => el.type === "pcb_component",
@@ -309,9 +337,10 @@ export function checkPcbComponentsOutOfBoard(
 
     if (compPoly.area() === 0) continue
 
-    // If component is entirely inside board polygon -> OK
-    // Flatten.Polygon.contains accepts shapes; this is the correct polygon containment check.
-    const isInside = boardPoly.contains(compPoly)
+    const isInside = isComponentInsideBoard({
+      componentPolygon: compPoly,
+      boardEdgeSpatialIndex,
+    })
     if (isInside) continue
 
     // Component is at least partially outside. Compute overlapDistance:

--- a/lib/utils/geometry/create-board-edge-spatial-index.ts
+++ b/lib/utils/geometry/create-board-edge-spatial-index.ts
@@ -1,0 +1,73 @@
+import * as Flatten from "@flatten-js/core"
+import { isPointInsidePolygon } from "@tscircuit/math-utils"
+import Flatbush from "flatbush"
+
+export interface BoardOutlinePoint {
+  x: number
+  y: number
+}
+
+export interface BoardEdgeSpatialIndex {
+  boardOutline: BoardOutlinePoint[]
+  boardPolygon: Flatten.Polygon
+  boardEdges: Flatten.Segment[]
+  boardEdgeBoundsIndex: Flatbush
+}
+
+export const createBoardEdgeSpatialIndex = (
+  boardOutline: BoardOutlinePoint[],
+): BoardEdgeSpatialIndex => {
+  const boardVertices = boardOutline.map(({ x, y }) => new Flatten.Point(x, y))
+  const boardPolygon = new Flatten.Polygon(boardVertices)
+  const boardEdges = boardVertices.map(
+    (start, index) =>
+      new Flatten.Segment(
+        start,
+        boardVertices[(index + 1) % boardVertices.length],
+      ),
+  )
+  const boardEdgeBoundsIndex = new Flatbush(boardEdges.length)
+  for (const boardEdge of boardEdges) {
+    const { xmin, ymin, xmax, ymax } = boardEdge.box
+    boardEdgeBoundsIndex.add(xmin, ymin, xmax, ymax)
+  }
+  boardEdgeBoundsIndex.finish()
+
+  return {
+    boardOutline,
+    boardPolygon,
+    boardEdges,
+    boardEdgeBoundsIndex,
+  }
+}
+
+export const getBoardEdgesNearBox = ({
+  box,
+  margin,
+  boardEdgeSpatialIndex,
+}: {
+  box: Flatten.Box
+  margin: number
+  boardEdgeSpatialIndex: BoardEdgeSpatialIndex
+}): Flatten.Segment[] => {
+  const boardEdgeIndices = boardEdgeSpatialIndex.boardEdgeBoundsIndex.search(
+    box.xmin - margin,
+    box.ymin - margin,
+    box.xmax + margin,
+    box.ymax + margin,
+  )
+  return boardEdgeIndices.map(
+    (boardEdgeIndex) => boardEdgeSpatialIndex.boardEdges[boardEdgeIndex],
+  )
+}
+
+export const arePointsInsideBoard = ({
+  points,
+  boardEdgeSpatialIndex,
+}: {
+  points: BoardOutlinePoint[]
+  boardEdgeSpatialIndex: BoardEdgeSpatialIndex
+}): boolean =>
+  points.every((point) =>
+    isPointInsidePolygon(point, boardEdgeSpatialIndex.boardOutline),
+  )

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "circuit-json": "*",
     "circuit-json-to-connectivity-map": "*",
     "typescript": "^5.5.3"
+  },
+  "dependencies": {
+    "flatbush": "^4.6.2"
   }
 }

--- a/tests/lib/check-copper-to-board-edge-clearance.test.ts
+++ b/tests/lib/check-copper-to-board-edge-clearance.test.ts
@@ -106,6 +106,64 @@ describe("copper-to-board-edge regression fixtures", () => {
       }),
     ).toMatchSvgSnapshot(import.meta.path, "copper-outside-board")
   })
+
+  test("checks detailed board outlines without scanning every edge per pad", () => {
+    const boardRadius = 50
+    const boardOutlinePointCount = 2_400
+    const interiorPadCount = 270
+    const maximumCheckDurationMs = 2_000
+    const detailedBoard: AnyCircuitElement = {
+      type: "pcb_board",
+      pcb_board_id: "detailed_board",
+      center: { x: 0, y: 0 },
+      width: boardRadius * 2,
+      height: boardRadius * 2,
+      num_layers: 2,
+      thickness: 1.6,
+      material: "fr4",
+      min_board_edge_clearance: 0.2,
+      outline: Array.from({ length: boardOutlinePointCount }, (_, index) => {
+        const angleRadians = (index / boardOutlinePointCount) * Math.PI * 2
+        return {
+          x: Math.cos(angleRadians) * boardRadius,
+          y: Math.sin(angleRadians) * boardRadius,
+        }
+      }),
+    }
+    const interiorPads: PcbSmtPad[] = Array.from(
+      { length: interiorPadCount },
+      (_, index) => ({
+        type: "pcb_smtpad",
+        pcb_smtpad_id: `interior_pad_${index}`,
+        shape: "circle",
+        x: (index % 18) - 9,
+        y: Math.floor(index / 18) - 7,
+        radius: 0.25,
+        layer: "top",
+      }),
+    )
+    const padBelowClearance: PcbSmtPad = {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "detailed_board_pad_below_clearance",
+      shape: "circle",
+      x: boardRadius - 0.3,
+      y: 0,
+      radius: 0.2,
+      layer: "top",
+    }
+
+    const start = performance.now()
+    const errors = checkCopperToBoardEdgeClearance([
+      detailedBoard,
+      ...interiorPads,
+      padBelowClearance,
+    ])
+    const durationMs = performance.now() - start
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain("detailed_board_pad_below_clearance")
+    expect(durationMs).toBeLessThan(maximumCheckDurationMs)
+  })
 })
 
 const rectangularBoard: AnyCircuitElement = {

--- a/tests/lib/pcb-component-boundary/detailed-board-outline-performance.test.ts
+++ b/tests/lib/pcb-component-boundary/detailed-board-outline-performance.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, PcbBoard, PcbComponent } from "circuit-json"
+import { checkPcbComponentsOutOfBoard } from "lib/check-pcb-components-out-of-board/checkPcbComponentsOutOfBoard"
+
+test("checks components against a detailed board outline efficiently", () => {
+  const boardRadius = 50
+  const boardOutlinePointCount = 2_400
+  const componentCount = 74
+  const maximumCheckDurationMs = 1_000
+  const board: PcbBoard = {
+    type: "pcb_board",
+    pcb_board_id: "detailed_board",
+    center: { x: 0, y: 0 },
+    width: boardRadius * 2,
+    height: boardRadius * 2,
+    num_layers: 2,
+    thickness: 1.6,
+    material: "fr4",
+    outline: Array.from({ length: boardOutlinePointCount }, (_, index) => {
+      const angleRadians = (index / boardOutlinePointCount) * Math.PI * 2
+      return {
+        x: Math.cos(angleRadians) * boardRadius,
+        y: Math.sin(angleRadians) * boardRadius,
+      }
+    }),
+  }
+  const components: PcbComponent[] = Array.from(
+    { length: componentCount },
+    (_, index) => ({
+      type: "pcb_component",
+      pcb_component_id: `pcb_component_${index}`,
+      source_component_id: `source_component_${index}`,
+      center: {
+        x: (index % 10) - 5,
+        y: Math.floor(index / 10) - 4,
+      },
+      width: 1,
+      height: 1,
+      layer: "top",
+      rotation: 0,
+      obstructs_within_bounds: true,
+    }),
+  )
+  const circuitJson: AnyCircuitElement[] = [board, ...components]
+
+  const start = performance.now()
+  const errors = checkPcbComponentsOutOfBoard(circuitJson)
+  const durationMs = performance.now() - start
+
+  expect(errors).toEqual([])
+  expect(durationMs).toBeLessThan(maximumCheckDurationMs)
+})


### PR DESCRIPTION
### Motivation
- Detailed board outlines caused placement DRC to repeatedly scan every outline edge for each pad and component.

### Before
- A 2,395-point drone outline took about 17.5 seconds to complete placement checks.

### After
- Spatially indexed board edges reduce the same check to about 0.97 seconds while preserving all eight diagnostics and add 2,400-point performance regressions.